### PR TITLE
스프링 시큐리티 기본 설정 추가 close #9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,10 +21,12 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/avalon/avalonchat/configuration/WebSecurityConfiguration.java
+++ b/src/main/java/com/avalon/avalonchat/configuration/WebSecurityConfiguration.java
@@ -1,0 +1,28 @@
+package com.avalon.avalonchat.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class WebSecurityConfiguration {
+
+	@Bean
+	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+		return http
+			.csrf().disable()
+			.formLogin().disable()
+			.httpBasic().disable()
+			.headers().disable()
+			.sessionManagement(session -> session
+				.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+			)
+			.authorizeRequests(authorize -> authorize
+				.antMatchers("/").permitAll()
+				.anyRequest().authenticated()
+			)
+			.build();
+	}
+}


### PR DESCRIPTION
## Summary
*스프링 시큐리티 기본 설정 추가 close #9

## Description
* dependencies 에 `spring-security-starter-security`, `spring-security-test` 추가하였습니다.
* WebSecurity 를 설정하는 방법이 여러가지가 있는데 과거에는 `WebSecurityConfigurerAdapter` 를 상속하여 설정하였었는데 최신 스프링에서는 Bean 기반 설정 방법을 권장합니다. (WebSecurityConfigurerAdapter 는 depercated 됨, 현재 버전도 deprecated 된 버전임)
* 그래서 Bean 기반 설정을 적용하였습니다.
<br>
* 내부에서 SecurityFilterChain 을 생성하는 방식에도 chaining 방식과 lambda dsl 방식이 있는데 둘다 적절히 활용해서 최대한 읽기 쉽다고 느껴지도록 작성하면 될것 같습니다. 아래 관련 링크 참고하시면 좋을것 같습니다..

https://spring.io/blog/2022/02/21/spring-security-without-the-websecurityconfigureradapter

## How Has This Been Tested?
현재 api 도 없고 일반적으로 설정 클래스 자체는 잘 테스트 하지 않는것 같습니다.
웹 브라우저로 동작을 확인하였습니다.
