### PR TITLE
회원 도메인 개발 + 더미 서비스/컨트롤러 #7

### DIFF
--- a/src/main/java/com/avalon/avalonchat/domain/user/controller/UserController.java
+++ b/src/main/java/com/avalon/avalonchat/domain/user/controller/UserController.java
@@ -1,0 +1,13 @@
+package com.avalon.avalonchat.domain.user.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class UserController {
+
+}

--- a/src/main/java/com/avalon/avalonchat/domain/user/domain/User.java
+++ b/src/main/java/com/avalon/avalonchat/domain/user/domain/User.java
@@ -1,0 +1,34 @@
+package com.avalon.avalonchat.domain.user.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "users")
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(updatable = false)
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String status;
+
+    @Column(name = "created_at", updatable = false, nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/avalon/avalonchat/domain/user/service/UserService.java
+++ b/src/main/java/com/avalon/avalonchat/domain/user/service/UserService.java
@@ -1,0 +1,4 @@
+package com.avalon.avalonchat.domain.user.service;
+
+public interface UserService {
+}

--- a/src/main/java/com/avalon/avalonchat/domain/user/service/UserServiceImp.java
+++ b/src/main/java/com/avalon/avalonchat/domain/user/service/UserServiceImp.java
@@ -1,0 +1,9 @@
+package com.avalon.avalonchat.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImp implements UserService{
+}


### PR DESCRIPTION
## Summary
회원 도메인 개발 + 더미 서비스/컨트롤러 #7

## Description
회원 도메인, 서비스, 컨트롤러 추가 했습니다.

[회원 도메인]
validation 사용 여부를 결정하지 않아서 제가 생각할때 최소한 해줘야할 설정 부분만 추가했습니다.
추가해야 할 부분이 있거나 수정 할 부분이 있으면 말씀해주세용

[회원 서비스]
서비스는 득윤님이 주신 url 읽어 봤습니다. 제 생각에는 확장성을 고려해 추상화 형태로 선택했습니다.
득윤님 url : https://wildeveloperetrain.tistory.com/m/49

[폴더 구조]
폴더 구조는 그때 득윤님이 하고싶어 하시던 도메인 구조로 할려했는데
구체적인 참고 자료가 없어서 제가 찾아서 해봤습니다. 아니면 말씀해주세요.
참고 : domain으로 구별 할수 없는 파일들은 global에 생성
참고 url : https://cheese10yun.github.io/spring-guide-directory/

## How Has This Been Tested?
h2로 테이블 생성 확인했습니다.