### PR TITLE
add profile domain, service, controller

### DIFF
--- a/src/main/java/com/avalon/avalonchat/domain/embed/EntityDate.java
+++ b/src/main/java/com/avalon/avalonchat/domain/embed/EntityDate.java
@@ -1,0 +1,20 @@
+package com.avalon.avalonchat.domain.embed;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import javax.persistence.Column;
+import java.time.LocalDateTime;
+
+/**
+ * 엔티티의 생성일, 수정일에 대한 Embeddable
+ */
+public class EntityDate {
+	@CreatedDate
+	@Column(name = "created_at", updatable = false, nullable = false)
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	@Column(name = "updated_at", nullable = false)
+	private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/avalon/avalonchat/domain/model/BaseDateTimeEntity.java
+++ b/src/main/java/com/avalon/avalonchat/domain/model/BaseDateTimeEntity.java
@@ -1,15 +1,18 @@
-package com.avalon.avalonchat.domain.embed;
+package com.avalon.avalonchat.domain.model;
 
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 
 import javax.persistence.Column;
+import javax.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
 
 /**
- * 엔티티의 생성일, 수정일에 대한 Embeddable
+ * 객체의 공통 매핑 정보
+ * 생성일, 수정일
  */
-public class EntityDate {
+@MappedSuperclass
+public class BaseDateTimeEntity {
 	@CreatedDate
 	@Column(name = "created_at", updatable = false, nullable = false)
 	private LocalDateTime createdAt;

--- a/src/main/java/com/avalon/avalonchat/domain/profile/controller/ProfileController.java
+++ b/src/main/java/com/avalon/avalonchat/domain/profile/controller/ProfileController.java
@@ -1,0 +1,11 @@
+package com.avalon.avalonchat.domain.profile.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class ProfileController {
+}

--- a/src/main/java/com/avalon/avalonchat/domain/profile/domain/Profile.java
+++ b/src/main/java/com/avalon/avalonchat/domain/profile/domain/Profile.java
@@ -1,0 +1,40 @@
+package com.avalon.avalonchat.domain.profile.domain;
+
+import com.avalon.avalonchat.domain.embed.EntityDate;
+import com.avalon.avalonchat.domain.user.domain.User;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "profiles")
+public class Profile {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(updatable = false)
+	private Long id;
+
+	@OneToOne
+	@JoinColumn(name = "users_id")
+	private User user;
+
+	@Column
+	private String bio;
+
+	@Column(name = "birth_date")
+	private LocalDateTime birthDate;
+
+	@Column
+	private String nickname;
+
+	@Column
+	private String phone;
+
+	@Embedded
+	private EntityDate entityDate;
+}

--- a/src/main/java/com/avalon/avalonchat/domain/profile/domain/Profile.java
+++ b/src/main/java/com/avalon/avalonchat/domain/profile/domain/Profile.java
@@ -1,25 +1,24 @@
 package com.avalon.avalonchat.domain.profile.domain;
 
-import com.avalon.avalonchat.domain.embed.EntityDate;
+import com.avalon.avalonchat.domain.model.BaseDateTimeEntity;
 import com.avalon.avalonchat.domain.user.domain.User;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "profiles")
-public class Profile {
+public class Profile extends BaseDateTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(updatable = false)
 	private Long id;
 
-	@OneToOne
+	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "users_id")
 	private User user;
 
@@ -27,14 +26,11 @@ public class Profile {
 	private String bio;
 
 	@Column(name = "birth_date")
-	private LocalDateTime birthDate;
+	private LocalDate birthDate;
 
 	@Column
 	private String nickname;
 
 	@Column
-	private String phone;
-
-	@Embedded
-	private EntityDate entityDate;
+	private String phoneNumber;
 }

--- a/src/main/java/com/avalon/avalonchat/domain/profile/service/ProfileService.java
+++ b/src/main/java/com/avalon/avalonchat/domain/profile/service/ProfileService.java
@@ -1,0 +1,4 @@
+package com.avalon.avalonchat.domain.profile.service;
+
+public interface ProfileService {
+}

--- a/src/main/java/com/avalon/avalonchat/domain/profile/service/ProfileServiceImp.java
+++ b/src/main/java/com/avalon/avalonchat/domain/profile/service/ProfileServiceImp.java
@@ -1,0 +1,10 @@
+package com.avalon.avalonchat.domain.profile.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ProfileServiceImp implements ProfileService {
+
+}

--- a/src/main/java/com/avalon/avalonchat/domain/user/domain/User.java
+++ b/src/main/java/com/avalon/avalonchat/domain/user/domain/User.java
@@ -1,5 +1,6 @@
 package com.avalon.avalonchat.domain.user.domain;
 
+import com.avalon.avalonchat.domain.embed.EntityDate;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -26,9 +27,6 @@ public class User {
     @Column(nullable = false)
     private String status;
 
-    @Column(name = "created_at", updatable = false, nullable = false)
-    private LocalDateTime createdAt;
-
-    @Column(name = "updated_at", nullable = false)
-    private LocalDateTime updatedAt;
+	@Embedded
+	private EntityDate entityDate;
 }

--- a/src/main/java/com/avalon/avalonchat/domain/user/domain/User.java
+++ b/src/main/java/com/avalon/avalonchat/domain/user/domain/User.java
@@ -1,32 +1,28 @@
 package com.avalon.avalonchat.domain.user.domain;
 
-import com.avalon.avalonchat.domain.embed.EntityDate;
+import com.avalon.avalonchat.domain.model.BaseDateTimeEntity;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
-import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "users")
-public class User {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(updatable = false)
-    private Long id;
+public class User extends BaseDateTimeEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(updatable = false)
+	private Long id;
 
-    @Column(unique = true, nullable = false)
-    private String email;
+	@Column(unique = true, nullable = false)
+	private String email;
 
-    @Column(nullable = false)
-    private String password;
+	@Column(nullable = false)
+	private String password;
 
-    @Column(nullable = false)
-    private String status;
-
-	@Embedded
-	private EntityDate entityDate;
+	@Column(nullable = false)
+	private String status;
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,1 +1,16 @@
+spring:
+  datasource:
+    url: jdbc:h2:tcp://localhost/~/avalon
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
 
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+
+logging.level:
+  org.hibernate.SQL: debug


### PR DESCRIPTION
## Summary

프로필 도메인, 더미 서비스/컨트롤러 [#13](https://github.com/avalon-202n/avalon-chat-backend/issues/13)

## (Optional): Description

프로필 도메인, 더미 서비스/컨트롤러를 추가했습니다.
폴더 구조는 성현님이 공유 해주신 걸 참고하여 개발했습니다.

`package com.avalon.avalonchat.domain.embed;` 경로로 Embed class 생성을 하였습니다.
created_at과 update_at만을 담을 클래스로, 위치와 클래스명은 애매해서 임의로 지었습니다.

## How Has This Been Tested?
H2에서 생성되는 걸 확인했습니다.

