### PR TITLE
chore: git submodule 디폴트 브랜치 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+/src/main/resources/libs/key/
+/src/main/resources/application.yml

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "avalon-chat-sub"]
 	path = avalon-chat-sub
 	url = https://github.com/avalon-202n/avalon-chat-sub.git
-  branch = dev
+  branch = main

--- a/build.gradle
+++ b/build.gradle
@@ -47,10 +47,13 @@ tasks.named('test') {
 
 task copyPrivate(type: Copy) {
     copy {
-        from './avalon-chat-privates'
-        include "*.yml"
+        from './avalon-chat-sub'
         into 'src/main/resources'
     }
+}
+
+processResources {
+    dependsOn copyPrivate
 }
 
 task checkstyle {

--- a/src/test/java/com/avalon/avalonchat/AvalonChatBackendApplicationTests.java
+++ b/src/test/java/com/avalon/avalonchat/AvalonChatBackendApplicationTests.java
@@ -1,6 +1,5 @@
 package com.avalon.avalonchat;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -8,7 +7,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 class AvalonChatBackendApplicationTests {
 
 	@Test
-	@Disabled
 	void contextLoads() {
 	}
 

--- a/src/test/java/com/avalon/avalonchat/domain/user/service/UserServiceImplTest.java
+++ b/src/test/java/com/avalon/avalonchat/domain/user/service/UserServiceImplTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.*;
 import static org.mockito.Mockito.*;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import com.avalon.avalonchat.domain.user.domain.User;


### PR DESCRIPTION
### 첫번째 커밋

1. 잘못되어 있었던 서브 모듈 설정 중 디폴트 브랜치 dev -> main 으로 수정

### 두번째 커밋

1. 서브 모듈에 키, .yml 추가

** 실수로 이전에 퍼블릭 레포지토리에 시크릿 값들을 올렸었는데, GCS 사용자 인증 키만 재발급받아서 새로 올렸는데, 혹시 버킷 자체를 새로 생성해야할까요?

### 세번째 커밋

1. git submodule에 추가된 파일 빌드시 resources/ 에 복사되도록 gradle.build 수정
2. 해당 파일들 gitignore 처리
