### PR TITLE
회원가입에 필요한 endpoint 서비스 계층 틀 잡기

### DIFF
--- a/src/main/java/com/avalon/avalonchat/domain/user/controller/SignUpController.java
+++ b/src/main/java/com/avalon/avalonchat/domain/user/controller/SignUpController.java
@@ -3,13 +3,22 @@ package com.avalon.avalonchat.domain.user.controller;
 import static com.avalon.avalonchat.global.error.ErrorResponseWithMessages.*;
 import static com.avalon.avalonchat.global.util.ResponseEntityUtil.*;
 
-import com.avalon.avalonchat.domain.user.dto.*;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.avalon.avalonchat.domain.user.dto.EmailAuthenticationCheckRequest;
+import com.avalon.avalonchat.domain.user.dto.EmailAuthenticationCheckResponse;
+import com.avalon.avalonchat.domain.user.dto.EmailAuthenticationSendRequest;
+import com.avalon.avalonchat.domain.user.dto.EmailDuplicatedCheckRequest;
+import com.avalon.avalonchat.domain.user.dto.EmailDuplicatedCheckResponse;
+import com.avalon.avalonchat.domain.user.dto.PhoneNumberAuthenticationCheckRequest;
+import com.avalon.avalonchat.domain.user.dto.PhoneNumberAuthenticationCheckResponse;
+import com.avalon.avalonchat.domain.user.dto.PhoneNumberAuthenticationSendRequest;
+import com.avalon.avalonchat.domain.user.dto.SignUpRequest;
+import com.avalon.avalonchat.domain.user.dto.SignUpResponse;
 import com.avalon.avalonchat.domain.user.service.UserService;
 import com.avalon.avalonchat.global.openapi.ErrorResponseApi;
 

--- a/src/main/java/com/avalon/avalonchat/domain/user/controller/SignUpController.java
+++ b/src/main/java/com/avalon/avalonchat/domain/user/controller/SignUpController.java
@@ -3,21 +3,13 @@ package com.avalon.avalonchat.domain.user.controller;
 import static com.avalon.avalonchat.global.error.ErrorResponseWithMessages.*;
 import static com.avalon.avalonchat.global.util.ResponseEntityUtil.*;
 
+import com.avalon.avalonchat.domain.user.dto.*;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.avalon.avalonchat.domain.user.dto.EmailAuthenticationCheckRequest;
-import com.avalon.avalonchat.domain.user.dto.EmailAuthenticationCheckResponse;
-import com.avalon.avalonchat.domain.user.dto.EmailAuthenticationSendRequest;
-import com.avalon.avalonchat.domain.user.dto.EmailDuplicatedCheckRequest;
-import com.avalon.avalonchat.domain.user.dto.EmailDuplicatedCheckResponse;
-import com.avalon.avalonchat.domain.user.dto.PhoneNumberAuthenticationCheckResponse;
-import com.avalon.avalonchat.domain.user.dto.PhoneNumberAuthenticationSendRequest;
-import com.avalon.avalonchat.domain.user.dto.SignUpRequest;
-import com.avalon.avalonchat.domain.user.dto.SignUpResponse;
 import com.avalon.avalonchat.domain.user.service.UserService;
 import com.avalon.avalonchat.global.openapi.ErrorResponseApi;
 
@@ -53,7 +45,7 @@ public class SignUpController {
 	public EmailDuplicatedCheckResponse emailDuplicatedCheck(
 		@RequestBody EmailDuplicatedCheckRequest request
 	) {
-		return new EmailDuplicatedCheckResponse(false);
+		return userService.checkEmailDuplicated(request);
 	}
 
 	@Operation(summary = "이메일 인증번호 발송")
@@ -62,6 +54,7 @@ public class SignUpController {
 	public ResponseEntity<Void> emailAuthenticationSend(
 		@RequestBody EmailAuthenticationSendRequest request
 	) {
+		userService.sendEmailAuthentication(request);
 		return noContent();
 	}
 
@@ -71,7 +64,7 @@ public class SignUpController {
 	public EmailAuthenticationCheckResponse emailAuthenticationCheck(
 		@RequestBody EmailAuthenticationCheckRequest request
 	) {
-		return new EmailAuthenticationCheckResponse(true);
+		return userService.checkEmailAuthentication(request);
 	}
 
 	@Operation(summary = "핸드폰 인증번호 발송")
@@ -80,6 +73,7 @@ public class SignUpController {
 	public ResponseEntity<Void> phoneNumberAuthenticationSend(
 		@RequestBody PhoneNumberAuthenticationSendRequest request
 	) {
+		userService.sendPhoneNumberAuthentication(request);
 		return noContent();
 	}
 
@@ -87,8 +81,8 @@ public class SignUpController {
 	@ErrorResponseApi(messages = INVALID_FIELD, args = {"PhoneNumber 인증 번호"})
 	@PostMapping("/phonenumber/authenticate/check")
 	public PhoneNumberAuthenticationCheckResponse phoneNumberAuthenticationCheck(
-		@RequestBody PhoneNumberAuthenticationSendRequest request
+		@RequestBody PhoneNumberAuthenticationCheckRequest request
 	) {
-		return new PhoneNumberAuthenticationCheckResponse(true);
+		return userService.checkPhoneNumberAuthentication(request);
 	}
 }

--- a/src/main/java/com/avalon/avalonchat/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/avalon/avalonchat/domain/user/repository/UserRepository.java
@@ -9,4 +9,6 @@ import com.avalon.avalonchat.domain.user.domain.User;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 	Optional<User> findByEmail(Email email);
+
+	boolean existsByEmail(Email email);
 }

--- a/src/main/java/com/avalon/avalonchat/domain/user/service/UserService.java
+++ b/src/main/java/com/avalon/avalonchat/domain/user/service/UserService.java
@@ -1,9 +1,18 @@
 package com.avalon.avalonchat.domain.user.service;
 
-import com.avalon.avalonchat.domain.user.dto.SignUpRequest;
-import com.avalon.avalonchat.domain.user.dto.SignUpResponse;
+import com.avalon.avalonchat.domain.user.dto.*;
 
 public interface UserService {
 
 	SignUpResponse signUp(SignUpRequest signUpRequest);
+
+	EmailDuplicatedCheckResponse checkEmailDuplicated(EmailDuplicatedCheckRequest request);
+
+	void sendEmailAuthentication(EmailAuthenticationSendRequest request);
+
+	EmailAuthenticationCheckResponse checkEmailAuthentication(EmailAuthenticationCheckRequest request);
+
+	void sendPhoneNumberAuthentication(PhoneNumberAuthenticationSendRequest request);
+
+	PhoneNumberAuthenticationCheckResponse checkPhoneNumberAuthentication(PhoneNumberAuthenticationCheckRequest request);
 }

--- a/src/main/java/com/avalon/avalonchat/domain/user/service/UserService.java
+++ b/src/main/java/com/avalon/avalonchat/domain/user/service/UserService.java
@@ -1,6 +1,15 @@
 package com.avalon.avalonchat.domain.user.service;
 
-import com.avalon.avalonchat.domain.user.dto.*;
+import com.avalon.avalonchat.domain.user.dto.EmailAuthenticationCheckRequest;
+import com.avalon.avalonchat.domain.user.dto.EmailAuthenticationCheckResponse;
+import com.avalon.avalonchat.domain.user.dto.EmailAuthenticationSendRequest;
+import com.avalon.avalonchat.domain.user.dto.EmailDuplicatedCheckRequest;
+import com.avalon.avalonchat.domain.user.dto.EmailDuplicatedCheckResponse;
+import com.avalon.avalonchat.domain.user.dto.PhoneNumberAuthenticationCheckRequest;
+import com.avalon.avalonchat.domain.user.dto.PhoneNumberAuthenticationCheckResponse;
+import com.avalon.avalonchat.domain.user.dto.PhoneNumberAuthenticationSendRequest;
+import com.avalon.avalonchat.domain.user.dto.SignUpRequest;
+import com.avalon.avalonchat.domain.user.dto.SignUpResponse;
 
 public interface UserService {
 
@@ -14,5 +23,6 @@ public interface UserService {
 
 	void sendPhoneNumberAuthentication(PhoneNumberAuthenticationSendRequest request);
 
-	PhoneNumberAuthenticationCheckResponse checkPhoneNumberAuthentication(PhoneNumberAuthenticationCheckRequest request);
+	PhoneNumberAuthenticationCheckResponse checkPhoneNumberAuthentication(
+		PhoneNumberAuthenticationCheckRequest request);
 }

--- a/src/main/java/com/avalon/avalonchat/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/avalon/avalonchat/domain/user/service/UserServiceImpl.java
@@ -1,10 +1,19 @@
 package com.avalon.avalonchat.domain.user.service;
 
-import com.avalon.avalonchat.domain.user.domain.Email;
-import com.avalon.avalonchat.domain.user.dto.*;
 import org.springframework.stereotype.Service;
 
+import com.avalon.avalonchat.domain.user.domain.Email;
 import com.avalon.avalonchat.domain.user.domain.User;
+import com.avalon.avalonchat.domain.user.dto.EmailAuthenticationCheckRequest;
+import com.avalon.avalonchat.domain.user.dto.EmailAuthenticationCheckResponse;
+import com.avalon.avalonchat.domain.user.dto.EmailAuthenticationSendRequest;
+import com.avalon.avalonchat.domain.user.dto.EmailDuplicatedCheckRequest;
+import com.avalon.avalonchat.domain.user.dto.EmailDuplicatedCheckResponse;
+import com.avalon.avalonchat.domain.user.dto.PhoneNumberAuthenticationCheckRequest;
+import com.avalon.avalonchat.domain.user.dto.PhoneNumberAuthenticationCheckResponse;
+import com.avalon.avalonchat.domain.user.dto.PhoneNumberAuthenticationSendRequest;
+import com.avalon.avalonchat.domain.user.dto.SignUpRequest;
+import com.avalon.avalonchat.domain.user.dto.SignUpResponse;
 import com.avalon.avalonchat.domain.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -52,7 +61,8 @@ public class UserServiceImpl implements UserService {
 		String certificationCode = request.getCertificationCode();
 
 		// check exists
-		// boolean exists = redisTemplate/emailAuthRepository.existsBy(signUpId, email. certificationCode); ??
+		// boolean exists
+		//  	= redisTemplate/emailAuthRepository.existsBy(signUpId, email. certificationCode); ??
 		boolean exist = false;
 
 		return new EmailAuthenticationCheckResponse(exist);
@@ -67,12 +77,14 @@ public class UserServiceImpl implements UserService {
 	}
 
 	@Override
-	public PhoneNumberAuthenticationCheckResponse checkPhoneNumberAuthentication(PhoneNumberAuthenticationCheckRequest request) {
+	public PhoneNumberAuthenticationCheckResponse checkPhoneNumberAuthentication(
+		PhoneNumberAuthenticationCheckRequest request) {
 		String phoneNumber = request.getPhoneNumber();
 		String certificationCode = request.getCertificationCode();
 
 		// check
-		// boolean exists = redisTemplate/phoneNumberAuthRepository.existsBy(signUpId, phoneNumber, certificationCode); ??
+		// boolean exists
+		// 		= redisTemplate/phoneNumberAuthRepository.existsBy(signUpId, phoneNumber, certificationCode); ??
 		boolean exist = false;
 
 		return new PhoneNumberAuthenticationCheckResponse(exist);

--- a/src/main/java/com/avalon/avalonchat/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/avalon/avalonchat/domain/user/service/UserServiceImpl.java
@@ -1,10 +1,10 @@
 package com.avalon.avalonchat.domain.user.service;
 
+import com.avalon.avalonchat.domain.user.domain.Email;
+import com.avalon.avalonchat.domain.user.dto.*;
 import org.springframework.stereotype.Service;
 
 import com.avalon.avalonchat.domain.user.domain.User;
-import com.avalon.avalonchat.domain.user.dto.SignUpRequest;
-import com.avalon.avalonchat.domain.user.dto.SignUpResponse;
 import com.avalon.avalonchat.domain.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -27,5 +27,54 @@ public class UserServiceImpl implements UserService {
 
 		// convert to response
 		return SignUpResponse.ofEntity(savedUser);
+	}
+
+	@Override
+	public EmailDuplicatedCheckResponse checkEmailDuplicated(EmailDuplicatedCheckRequest request) {
+		Email email = request.getEmail();
+
+		boolean exists = userRepository.existsByEmail(email);
+
+		return new EmailDuplicatedCheckResponse(exists);
+	}
+
+	@Override
+	public void sendEmailAuthentication(EmailAuthenticationSendRequest request) {
+		Email email = request.getEmail();
+
+		// 2. send email
+		// emailService.sendAuthCode(signUpId, email); ??
+	}
+
+	@Override
+	public EmailAuthenticationCheckResponse checkEmailAuthentication(EmailAuthenticationCheckRequest request) {
+		Email email = request.getEmail();
+		String certificationCode = request.getCertificationCode();
+
+		// check exists
+		// boolean exists = redisTemplate/emailAuthRepository.existsBy(signUpId, email. certificationCode); ??
+		boolean exist = false;
+
+		return new EmailAuthenticationCheckResponse(exist);
+	}
+
+	@Override
+	public void sendPhoneNumberAuthentication(PhoneNumberAuthenticationSendRequest request) {
+		String phoneNumber = request.getPhoneNumber();
+
+		// send
+		// phoneMessageService.sendAuthCode(signUpId, phoneNumber); ??
+	}
+
+	@Override
+	public PhoneNumberAuthenticationCheckResponse checkPhoneNumberAuthentication(PhoneNumberAuthenticationCheckRequest request) {
+		String phoneNumber = request.getPhoneNumber();
+		String certificationCode = request.getCertificationCode();
+
+		// check
+		// boolean exists = redisTemplate/phoneNumberAuthRepository.existsBy(signUpId, phoneNumber, certificationCode); ??
+		boolean exist = false;
+
+		return new PhoneNumberAuthenticationCheckResponse(exist);
 	}
 }

--- a/src/test/java/com/avalon/avalonchat/domain/user/service/UserServiceImplTest.java
+++ b/src/test/java/com/avalon/avalonchat/domain/user/service/UserServiceImplTest.java
@@ -1,40 +1,50 @@
 package com.avalon.avalonchat.domain.user.service;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.*;
-import static org.mockito.Mockito.*;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 
-import com.avalon.avalonchat.domain.user.domain.User;
+import com.avalon.avalonchat.domain.user.domain.Email;
+import com.avalon.avalonchat.domain.user.dto.EmailDuplicatedCheckRequest;
+import com.avalon.avalonchat.domain.user.dto.EmailDuplicatedCheckResponse;
 import com.avalon.avalonchat.domain.user.dto.SignUpRequest;
 import com.avalon.avalonchat.domain.user.dto.SignUpResponse;
-import com.avalon.avalonchat.domain.user.repository.UserRepository;
 import com.avalon.avalonchat.testsupport.DtoFixture;
-import com.avalon.avalonchat.testsupport.Fixture;
 
+@SpringBootTest
 class UserServiceImplTest {
 
+	@Autowired
 	private UserServiceImpl sut;
-	private UserRepository userRepository;
-
-	@BeforeEach
-	void setUp() {
-		userRepository = mock(UserRepository.class);
-		sut = new UserServiceImpl(userRepository);
-	}
 
 	@Test
 	void 회원가입_성공() {
 		//given
 		SignUpRequest request = DtoFixture.signUpRequest("hello@wolrd.com", "passw0rd");
-		User savedUser = Fixture.createUser("hello@wolrd.com", "passw0rd");
-		when(userRepository.save(any(User.class))).thenReturn(savedUser);
 
 		//when
 		SignUpResponse response = sut.signUp(request);
 
 		//then
-		assertThat(response.getEmail()).isEqualTo(savedUser.getEmail());
+		assertThat(response.getEmail()).isEqualTo(request.getEmail());
+	}
+
+	@Test
+	void 이메일_중복_확인_성공() {
+		//given
+		SignUpRequest request = DtoFixture.signUpRequest("savedUser@wolrd.com", "passw0rd");
+		sut.signUp(request);
+
+		//when
+		EmailDuplicatedCheckResponse trueResponse =
+			sut.checkEmailDuplicated(new EmailDuplicatedCheckRequest(request.getEmail()));
+		EmailDuplicatedCheckResponse falseResponse =
+			sut.checkEmailDuplicated(new EmailDuplicatedCheckRequest(Email.of("unsavedUser@world.com")));
+
+		//then
+		assertThat(trueResponse.isDuplicated()).isTrue();
+		assertThat(falseResponse.isDuplicated()).isFalse();
 	}
 }


### PR DESCRIPTION
## Summary
회원가입에 필요한 endpoint 서비스 계층 틀 잡기
- signup 과정 자체에 대한 id 를 임시로 가지고 있어야 진행중인 signup 에 대해 이메일/핸드폰 인증번호 검사를 할수 있을거 같다는 생각이 들었어요. 그래서 api docs 에 없지만 signupId 를 일단 서비스 계층에만 제가 생각하는 형태로 주석으로 코드를 적어놓았습니다.

## How Has This Been Tested?
- 완성된 기능 (이메일 중복 확인)에 대해서만 테스트 했습니다.
- 서비스 계층의 테스트는 저번에 이야기 한 대로 @SpringBootTest 애너테이션을 이용하도록 바꾸었습니다.
