### PR TITLE
chore: 프로필 생성 로직 수정

### DIFF
--- a/src/main/java/com/avalon/avalonchat/domain/profile/controller/ProfileController.java
+++ b/src/main/java/com/avalon/avalonchat/domain/profile/controller/ProfileController.java
@@ -5,6 +5,7 @@ import static com.avalon.avalonchat.global.util.ResponseEntityUtil.*;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -12,6 +13,7 @@ import com.avalon.avalonchat.domain.profile.dto.ProfileAddRequest;
 import com.avalon.avalonchat.domain.profile.dto.ProfileAddResponse;
 import com.avalon.avalonchat.domain.profile.service.ProfileService;
 
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -23,14 +25,15 @@ public class ProfileController {
 
 	private final ProfileService profileService;
 
+	@Operation(
+		summary = "프로필 생성",
+		description = "헤더의 user_id를 통해 회원과 매핑"
+	)
 	@PostMapping
 	public ResponseEntity<ProfileAddResponse> addProfile(
-		//TODO: @AuthenticationPrincipal 활용 -> SecurityUser 타입 Authentication 객체에서 userId 가져올 것
+		@RequestHeader("user-id") Long userId,
 		@RequestBody ProfileAddRequest request
 	) {
-		// setup
-		long userId = 1L;
-
 		// action
 		ProfileAddResponse response = profileService.addProfile(userId, request);
 

--- a/src/main/java/com/avalon/avalonchat/domain/profile/domain/Profile.java
+++ b/src/main/java/com/avalon/avalonchat/domain/profile/domain/Profile.java
@@ -48,11 +48,12 @@ public class Profile extends BaseAuditingEntity {
 	@OneToMany(mappedBy = "profile", cascade = CascadeType.PERSIST, orphanRemoval = true)
 	private List<BackgroundImage> backgroundImages = new ArrayList<>();
 
-	public Profile(User user, String bio, LocalDate birthDate, String nickname) {
+	public Profile(User user, String bio, LocalDate birthDate, String nickname, String phoneNumber) {
 		this.user = user;
 		this.bio = bio;
 		this.birthDate = birthDate;
 		this.nickname = nickname;
+		this.phoneNumber = phoneNumber;
 	}
 
 	public void addProfileImage(ProfileImage profileImage) {

--- a/src/main/java/com/avalon/avalonchat/domain/profile/dto/ProfileAddRequest.java
+++ b/src/main/java/com/avalon/avalonchat/domain/profile/dto/ProfileAddRequest.java
@@ -27,17 +27,22 @@ public class ProfileAddRequest {
 	@Schema(description = "배경 이미지 주소", example = "http://background/image/url")
 	private final String backgroundImageUrl;
 
+	@Schema(description = "핸드폰 번호", example = "010-1234-5678")
+	private final String phoneNumber;
+
 	public ProfileAddRequest(
 		LocalDate birthDate,
 		String nickname,
 		String bio,
 		String profileImageUrl,
-		String backgroundImageUrl
+		String backgroundImageUrl,
+		String phoneNumber
 	) {
 		this.birthDate = birthDate;
 		this.nickname = nickname;
 		this.bio = bio;
 		this.profileImageUrl = profileImageUrl;
 		this.backgroundImageUrl = backgroundImageUrl;
+		this.phoneNumber = phoneNumber;
 	}
 }

--- a/src/main/java/com/avalon/avalonchat/domain/profile/dto/ProfileAddResponse.java
+++ b/src/main/java/com/avalon/avalonchat/domain/profile/dto/ProfileAddResponse.java
@@ -1,6 +1,8 @@
 package com.avalon.avalonchat.domain.profile.dto;
 
 import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import com.avalon.avalonchat.domain.profile.domain.BackgroundImage;
 import com.avalon.avalonchat.domain.profile.domain.Profile;
@@ -13,20 +15,23 @@ public class ProfileAddResponse {
 	private final LocalDate birthDate;
 	private final String nickname;
 	private final String bio;
-	private final String[] profileImages;
-	private final String[] backgroundImages;
+	private final List<String> profileImages;
+	private final List<String> backgroundImages;
+	private final String phoneNumber;
 
 	public ProfileAddResponse(
 		LocalDate birthDate,
 		String nickname,
 		String bio,
-		String[] profileImages,
-		String[] backgroundImages) {
+		List<String> profileImages,
+		List<String> backgroundImages,
+		String phoneNumber) {
 		this.birthDate = birthDate;
 		this.nickname = nickname;
 		this.bio = bio;
 		this.profileImages = profileImages;
 		this.backgroundImages = backgroundImages;
+		this.phoneNumber = phoneNumber;
 	}
 
 	public static ProfileAddResponse ofEntity(Profile profile) {
@@ -36,10 +41,11 @@ public class ProfileAddResponse {
 			profile.getBio(),
 			profile.getProfileImages().stream()
 				.map(ProfileImage::getUrl)
-				.toArray(String[]::new),
+				.collect(Collectors.toList()),
 			profile.getBackgroundImages().stream()
 				.map(BackgroundImage::getUrl)
-				.toArray(String[]::new)
+				.collect(Collectors.toList()),
+			profile.getPhoneNumber()
 		);
 	}
 }

--- a/src/main/java/com/avalon/avalonchat/domain/profile/exception/UnAuthenticatedPhoneNumberException.java
+++ b/src/main/java/com/avalon/avalonchat/domain/profile/exception/UnAuthenticatedPhoneNumberException.java
@@ -1,0 +1,9 @@
+package com.avalon.avalonchat.domain.profile.exception;
+
+import com.avalon.avalonchat.global.error.exception.AvalonChatRuntimeException;
+
+public class UnAuthenticatedPhoneNumberException extends AvalonChatRuntimeException {
+	public UnAuthenticatedPhoneNumberException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/avalon/avalonchat/domain/profile/service/ProfileServiceImpl.java
+++ b/src/main/java/com/avalon/avalonchat/domain/profile/service/ProfileServiceImpl.java
@@ -9,6 +9,7 @@ import com.avalon.avalonchat.domain.profile.domain.Profile;
 import com.avalon.avalonchat.domain.profile.domain.ProfileImage;
 import com.avalon.avalonchat.domain.profile.dto.ProfileAddRequest;
 import com.avalon.avalonchat.domain.profile.dto.ProfileAddResponse;
+import com.avalon.avalonchat.domain.profile.exception.UnAuthenticatedPhoneNumberException;
 import com.avalon.avalonchat.domain.profile.repository.ProfileRepository;
 import com.avalon.avalonchat.domain.user.domain.PhoneNumberAuthenticationCode;
 import com.avalon.avalonchat.domain.user.domain.User;
@@ -33,14 +34,16 @@ public class ProfileServiceImpl
 	public ProfileAddResponse addProfile(long userId, ProfileAddRequest request) {
 		// 1. find user
 		User user = userRepository.findById(userId)
-			.orElseThrow(() -> new AvalonChatRuntimeException("User Not Found"));
+			.orElseThrow(() -> new AvalonChatRuntimeException("user not found for userId: " + userId));
 
 		// 2. check
 		String phoneNumber = request.getPhoneNumber();
 		PhoneNumberAuthenticationCode phoneNumberAuthenticationCode = phoneNumberAuthenticationRepository.findById(
-			phoneNumber).orElseThrow(() -> new AvalonChatRuntimeException("인증번호를 받지 않은 사용자입니다."));
+				phoneNumber)
+			.orElseThrow(
+				() -> new AvalonChatRuntimeException("certificationCode not found for phoneNumber: " + phoneNumber));
 		if (!phoneNumberAuthenticationCode.isAuthenticated()) {
-			throw new AvalonChatRuntimeException("인증되지 않은 휴대전화번호 입니다.");
+			throw new UnAuthenticatedPhoneNumberException("unAuthenticated phoneNumber: " + phoneNumber);
 		}
 
 		// 3. create profile

--- a/src/main/java/com/avalon/avalonchat/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/avalon/avalonchat/domain/user/service/UserServiceImpl.java
@@ -112,7 +112,9 @@ public class UserServiceImpl implements UserService {
 
 		// 2. check: if equals authenticate and return true, if not return false
 		PhoneNumberAuthenticationCode phoneNumberAuthenticationCode = phoneNumberAuthenticationRepository.findById(
-			phoneNumber).orElseThrow(() -> new AvalonChatRuntimeException("인증번호를 받지 않은 사용자입니다."));
+				phoneNumber)
+			.orElseThrow(
+				() -> new AvalonChatRuntimeException("certificationCode not found for phoneNumber:" + phoneNumber));
 
 		if (phoneNumberAuthenticationCode.getCertificationCode().equals(certificationCode)) {
 			phoneNumberAuthenticationCode.authenticate();

--- a/src/main/java/com/avalon/avalonchat/global/configuration/jwt/JwtTokenService.java
+++ b/src/main/java/com/avalon/avalonchat/global/configuration/jwt/JwtTokenService.java
@@ -24,10 +24,10 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 public class JwtTokenService {
 
+	private final JwtParser jwtParser;
 	private long accessValidity;
 	private long refreshValidity;
 	private Key secretKey;
-	private final JwtParser jwtParser;
 
 	@Autowired
 	public JwtTokenService(JwtConfigProperties properties) {

--- a/src/test/java/com/avalon/avalonchat/domain/friend/domain/FriendTest.java
+++ b/src/test/java/com/avalon/avalonchat/domain/friend/domain/FriendTest.java
@@ -19,8 +19,9 @@ class FriendTest {
 		User myUser = new User(Email.of("email1@gmail.com"), Password.of("password1"));
 		User friendUser = new User(Email.of("email2@gmail.com"), Password.of("password2"));
 
-		Profile myProfile = new Profile(myUser, "bio1", LocalDate.now(), "nickname1");
-		Profile friendProfile = new Profile(friendUser, "bio2", LocalDate.now(), "nickname2");
+		String phoneNumber = "01055110625";
+		Profile myProfile = new Profile(myUser, "bio1", LocalDate.now(), "nickname1", phoneNumber);
+		Profile friendProfile = new Profile(friendUser, "bio2", LocalDate.now(), "nickname2", phoneNumber);
 
 		//when
 		Friend friend = new Friend(myProfile, friendProfile);

--- a/src/test/java/com/avalon/avalonchat/domain/friend/repository/FriendRepositoryTest.java
+++ b/src/test/java/com/avalon/avalonchat/domain/friend/repository/FriendRepositoryTest.java
@@ -36,8 +36,10 @@ class FriendRepositoryTest {
 		User myUser = new User(Email.of("email1@gmail.com"), Password.of("password1"));
 		User friendUser = new User(Email.of("email2@gmail.com"), Password.of("password2"));
 
-		Profile myProfile = new Profile(myUser, "bio1", LocalDate.now(), "nickname1");
-		Profile friendProfile = new Profile(friendUser, "bio2", LocalDate.now(), "nickname2");
+		String phoneNumber = "01055110625";
+
+		Profile myProfile = new Profile(myUser, "bio1", LocalDate.now(), "nickname1", phoneNumber);
+		Profile friendProfile = new Profile(friendUser, "bio2", LocalDate.now(), "nickname2", phoneNumber);
 
 		Friend friend = new Friend(myProfile, friendProfile);
 
@@ -53,12 +55,12 @@ class FriendRepositoryTest {
 	void Friend_Profile_다대일_매핑_성공() {
 		// given
 		User myUser = new User(Email.of("email1@gmail.com"), Password.of("password1"));
-		Profile myProfile = new Profile(myUser, "bio1", LocalDate.now(), "nickname1");
+		Profile myProfile = new Profile(myUser, "bio1", LocalDate.now(), "nickname1", "01055110625");
 
 		User friendUser1 = new User(Email.of("email2@gmail.com"), Password.of("password2"));
-		Profile friendProfile1 = new Profile(friendUser1, "bio2", LocalDate.now(), "nickname2");
+		Profile friendProfile1 = new Profile(friendUser1, "bio2", LocalDate.now(), "nickname2", "01055110625");
 		User friendUser2 = new User(Email.of("email3@gmail.com"), Password.of("password3"));
-		Profile friendProfile2 = new Profile(friendUser2, "bio4", LocalDate.now(), "nickname4");
+		Profile friendProfile2 = new Profile(friendUser2, "bio4", LocalDate.now(), "nickname4", "01055110625");
 
 		Friend friend1 = new Friend(myProfile, friendProfile1);
 		Friend friend2 = new Friend(myProfile, friendProfile2);
@@ -86,7 +88,7 @@ class FriendRepositoryTest {
 	void Friend_벌크_저장_성공() {
 		// given
 		User myUser = new User(Email.of("email@gmail.com"), Password.of("password"));
-		Profile myProfile = new Profile(myUser, "bio", LocalDate.now(), "nickname");
+		Profile myProfile = new Profile(myUser, "bio", LocalDate.now(), "nickname", "01055110625");
 
 		userRepository.save(myUser);
 		profileRepository.save(myProfile);
@@ -95,7 +97,7 @@ class FriendRepositoryTest {
 
 		for (int i = 0; i < 10; i++) {
 			User friendUser = new User(Email.of("email@gmail" + i + ".com"), Password.of("password" + i));
-			Profile friendProfile = new Profile(friendUser, "bio", LocalDate.now(), "nickname");
+			Profile friendProfile = new Profile(friendUser, "bio", LocalDate.now(), "nickname", "01055110625");
 			Friend friend = new Friend(myProfile, friendProfile);
 
 			userRepository.save(friendUser);

--- a/src/test/java/com/avalon/avalonchat/domain/friend/service/FriendServiceImplTest.java
+++ b/src/test/java/com/avalon/avalonchat/domain/friend/service/FriendServiceImplTest.java
@@ -51,9 +51,11 @@ class FriendServiceImplTest {
 		User savedFriendUser1 = userRepository.save(friendUser1);
 		User savedFriendUser2 = userRepository.save(friendUser2);
 
-		Profile myProfile = new Profile(savedMyUser, "bio", LocalDate.now(), "nickname");
-		Profile friendProfile1 = new Profile(savedFriendUser1, "bio1", LocalDate.now(), "nickname1");
-		Profile friendProfile2 = new Profile(savedFriendUser2, "bio2", LocalDate.now(), "nickname2");
+		String phoneNumber = "01055110625";
+
+		Profile myProfile = new Profile(savedMyUser, "bio", LocalDate.now(), "nickname", phoneNumber);
+		Profile friendProfile1 = new Profile(savedFriendUser1, "bio1", LocalDate.now(), "nickname1", phoneNumber);
+		Profile friendProfile2 = new Profile(savedFriendUser2, "bio2", LocalDate.now(), "nickname2", phoneNumber);
 		friendProfile1.setPhoneNumber(phoneNumber1);
 		friendProfile2.setPhoneNumber(phoneNumber2);
 

--- a/src/test/java/com/avalon/avalonchat/domain/profile/domain/BackgroundImageTest.java
+++ b/src/test/java/com/avalon/avalonchat/domain/profile/domain/BackgroundImageTest.java
@@ -16,7 +16,7 @@ class BackgroundImageTest {
 	void backgroundImage_생성성공() {
 		//given
 		User user = new User(Email.of("email@gmail.com"), Password.of("password"));
-		Profile profile = new Profile(user, "bio", LocalDate.now(), "nickname");
+		Profile profile = new Profile(user, "bio", LocalDate.now(), "nickname", "01055110625");
 		String url = "storage/url/image.png";
 
 		//when

--- a/src/test/java/com/avalon/avalonchat/domain/profile/domain/ProfileImageTest.java
+++ b/src/test/java/com/avalon/avalonchat/domain/profile/domain/ProfileImageTest.java
@@ -15,7 +15,7 @@ class ProfileImageTest {
 	void profileImage_생성성공() {
 		//given
 		User user = new User(Email.of("email@gmail.com"), Password.of("password"));
-		Profile profile = new Profile(user, "bio", LocalDate.now(), "nickname");
+		Profile profile = new Profile(user, "bio", LocalDate.now(), "nickname", "01055110625");
 		String url = "storage/url/image.png";
 
 		//when

--- a/src/test/java/com/avalon/avalonchat/domain/profile/domain/ProfileTest.java
+++ b/src/test/java/com/avalon/avalonchat/domain/profile/domain/ProfileTest.java
@@ -23,8 +23,10 @@ class ProfileTest {
 		String profileUrl = "storage/url/profile_image.png";
 		String backgroundUrl = "storage/url/background_image.png";
 
+		String phoneNumber = "01055110625";
+
 		// when
-		Profile profile = new Profile(user, bio, birthDate, nickname);
+		Profile profile = new Profile(user, bio, birthDate, nickname, phoneNumber);
 
 		ProfileImage profileImage = new ProfileImage(profile, profileUrl);
 		BackgroundImage backgroundImage = new BackgroundImage(profile, backgroundUrl);

--- a/src/test/java/com/avalon/avalonchat/domain/profile/repository/ProfileRepositoryTest.java
+++ b/src/test/java/com/avalon/avalonchat/domain/profile/repository/ProfileRepositoryTest.java
@@ -44,7 +44,9 @@ class ProfileRepositoryTest {
 		String profileUrl = "storage/url/profile_image.png";
 		String backgroundUrl = "storage/url/background_image.png";
 
-		Profile profile = new Profile(user, bio, birthDate, nickname);
+		String phoneNumber = "01055110625";
+
+		Profile profile = new Profile(user, bio, birthDate, nickname, phoneNumber);
 
 		ProfileImage profileImage = new ProfileImage(profile, profileUrl);
 		BackgroundImage backgroundImage = new BackgroundImage(profile, backgroundUrl);
@@ -74,6 +76,7 @@ class ProfileRepositoryTest {
 		String phoneNumber1 = "010-1234-5678";
 		String phoneNumber2 = "010-8765-4321";
 		String[] phoneNumbers = {phoneNumber1, phoneNumber2};
+		String phoneNumber = "01055110625";
 
 		User myUser = new User(Email.of("email@gmail.com"), Password.of("password"));
 		User friendUser1 = new User(Email.of("email@gmail1.com"), Password.of("password1"));
@@ -82,9 +85,9 @@ class ProfileRepositoryTest {
 		User savedFriendUser1 = userRepository.save(friendUser1);
 		User savedFriendUser2 = userRepository.save(friendUser2);
 
-		Profile myProfile = new Profile(savedMyUser, "bio", LocalDate.now(), "nickname");
-		Profile friendProfile1 = new Profile(savedFriendUser1, "bio1", LocalDate.now(), "nickname1");
-		Profile friendProfile2 = new Profile(savedFriendUser2, "bio2", LocalDate.now(), "nickname2");
+		Profile myProfile = new Profile(savedMyUser, "bio", LocalDate.now(), "nickname", phoneNumber);
+		Profile friendProfile1 = new Profile(savedFriendUser1, "bio1", LocalDate.now(), "nickname1", phoneNumber);
+		Profile friendProfile2 = new Profile(savedFriendUser2, "bio2", LocalDate.now(), "nickname2", phoneNumber);
 		friendProfile1.setPhoneNumber(phoneNumber1);
 		friendProfile2.setPhoneNumber(phoneNumber2);
 		profileRepository.save(myProfile);

--- a/src/test/java/com/avalon/avalonchat/testsupport/Fixture.java
+++ b/src/test/java/com/avalon/avalonchat/testsupport/Fixture.java
@@ -20,18 +20,14 @@ public final class Fixture {
 		);
 	}
 
-	// FIXME - this method leads to invalid Profile where userId is null
-	public static Profile createProfile() {
-		User user = Fixture.createUser();
-		return createProfile(user, "bio", LocalDate.now(), "nickname");
-	}
-
-	public static Profile createProfile(User user, String bio, LocalDate birthDate, String nickname) {
+	public static Profile createProfile(User user, String bio, LocalDate birthDate, String nickname,
+		String phoneNumber) {
 		return new Profile(
 			user,
 			bio,
 			birthDate,
-			nickname
+			nickname,
+			phoneNumber
 		);
 	}
 }


### PR DESCRIPTION
## Summary

*프로필 생성 로직 수정*

## (Optional): Description

*프로필 생성 요청시 헤더에 user-id 전송*
*프로필 요청 dto에 담긴 핸드폰 번호가 redis에 존재하는지, 인증여부가 True인지 확인*
*프로필 응답 dto의 문자열 배열 -> Collections로 수정*

## How Has This Been Tested?

*핸드폰 번호로 인증 완료 후, 해당 핸드폰 번호와 Users id(PK)로 사용자 인증 검증 및 프로필 생성 테스트*
*인증되지 않은 사용자인 경우, UnAuthenticatedException 예외 발생 테스트*
