### PR TITLE
feat: 친구 상태 변경

### DIFF
--- a/src/main/java/com/avalon/avalonchat/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/avalon/avalonchat/domain/friend/controller/FriendController.java
@@ -6,12 +6,17 @@ import java.util.List;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.avalon.avalonchat.domain.friend.dto.FriendAddRequest;
 import com.avalon.avalonchat.domain.friend.dto.FriendAddResponse;
+import com.avalon.avalonchat.domain.friend.dto.FriendStatusUpdateRequest;
+import com.avalon.avalonchat.domain.friend.dto.FriendStatusUpdateResponse;
 import com.avalon.avalonchat.domain.friend.service.FriendService;
 import com.avalon.avalonchat.domain.model.SecurityUser;
 
@@ -39,5 +44,19 @@ public class FriendController {
 	) {
 		List<FriendAddResponse> responses = friendService.addFriend(securityUser.getProfileId(), request);
 		return created(responses);
+	}
+
+	@Operation(
+		summary = "친구 상태 변경",
+		description = "friendProfileId를 사용해 현재 로그인된 회원의 친구의 상태를 변경합니다.",
+		security = {@SecurityRequirement(name = "bearer-key")}
+	)
+	@PatchMapping("/{friendProfileId}")
+	public FriendStatusUpdateResponse updateFriendStatus(
+		@AuthenticationPrincipal SecurityUser securityUser,
+		@PathVariable Long friendProfileId,
+		@RequestBody FriendStatusUpdateRequest request
+	) {
+		return friendService.updateFriendStatus(securityUser.getProfileId(), friendProfileId, request);
 	}
 }

--- a/src/main/java/com/avalon/avalonchat/domain/friend/domain/Friend.java
+++ b/src/main/java/com/avalon/avalonchat/domain/friend/domain/Friend.java
@@ -35,6 +35,10 @@ public class Friend extends BaseAuditingEntity {
 		this.friendProfile = friendProfile;
 	}
 
+	public void updateStatus(FriendStatus status) {
+		this.friendStatus = status;
+	}
+
 	/* 친구상태 종류 */
 	public enum FriendStatus {
 		NORMAL,

--- a/src/main/java/com/avalon/avalonchat/domain/friend/dto/FriendStatusUpdateRequest.java
+++ b/src/main/java/com/avalon/avalonchat/domain/friend/dto/FriendStatusUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.avalon.avalonchat.domain.friend.dto;
+
+import com.avalon.avalonchat.domain.friend.domain.Friend;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class FriendStatusUpdateRequest {
+	@Schema(description = "변경할 친구 상태", example = "NORMAL,FAVORITES,BLOCKED,HIDDEN 중 하나")
+	private Friend.FriendStatus status;
+
+	public FriendStatusUpdateRequest(String status) {
+		this.status = Friend.FriendStatus.valueOf(status);
+	}
+}

--- a/src/main/java/com/avalon/avalonchat/domain/friend/dto/FriendStatusUpdateResponse.java
+++ b/src/main/java/com/avalon/avalonchat/domain/friend/dto/FriendStatusUpdateResponse.java
@@ -1,0 +1,18 @@
+package com.avalon.avalonchat.domain.friend.dto;
+
+import com.avalon.avalonchat.domain.friend.domain.Friend;
+
+import lombok.Getter;
+
+@Getter
+public class FriendStatusUpdateResponse {
+	private final Friend.FriendStatus status;
+
+	public FriendStatusUpdateResponse(Friend.FriendStatus status) {
+		this.status = status;
+	}
+
+	public static FriendStatusUpdateResponse ofEntity(Friend friend) {
+		return new FriendStatusUpdateResponse(friend.getFriendStatus());
+	}
+}

--- a/src/main/java/com/avalon/avalonchat/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/com/avalon/avalonchat/domain/friend/repository/FriendRepository.java
@@ -1,8 +1,11 @@
 package com.avalon.avalonchat.domain.friend.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.avalon.avalonchat.domain.friend.domain.Friend;
 
 public interface FriendRepository extends JpaRepository<Friend, Long> {
+	Optional<Friend> findByMyProfileIdAndFriendProfileId(long myProfileId, long friendProfileId);
 }

--- a/src/main/java/com/avalon/avalonchat/domain/friend/service/FriendService.java
+++ b/src/main/java/com/avalon/avalonchat/domain/friend/service/FriendService.java
@@ -4,7 +4,12 @@ import java.util.List;
 
 import com.avalon.avalonchat.domain.friend.dto.FriendAddRequest;
 import com.avalon.avalonchat.domain.friend.dto.FriendAddResponse;
+import com.avalon.avalonchat.domain.friend.dto.FriendStatusUpdateRequest;
+import com.avalon.avalonchat.domain.friend.dto.FriendStatusUpdateResponse;
 
 public interface FriendService {
 	List<FriendAddResponse> addFriend(long id, FriendAddRequest request);
+
+	FriendStatusUpdateResponse updateFriendStatus(long myProfileId, long friendProfileId,
+		FriendStatusUpdateRequest request);
 }

--- a/src/main/java/com/avalon/avalonchat/domain/friend/service/FriendServiceImpl.java
+++ b/src/main/java/com/avalon/avalonchat/domain/friend/service/FriendServiceImpl.java
@@ -9,6 +9,8 @@ import org.springframework.transaction.annotation.Transactional;
 import com.avalon.avalonchat.domain.friend.domain.Friend;
 import com.avalon.avalonchat.domain.friend.dto.FriendAddRequest;
 import com.avalon.avalonchat.domain.friend.dto.FriendAddResponse;
+import com.avalon.avalonchat.domain.friend.dto.FriendStatusUpdateRequest;
+import com.avalon.avalonchat.domain.friend.dto.FriendStatusUpdateResponse;
 import com.avalon.avalonchat.domain.friend.repository.FriendRepository;
 import com.avalon.avalonchat.domain.profile.domain.Profile;
 import com.avalon.avalonchat.domain.profile.repository.ProfileRepository;
@@ -39,5 +41,20 @@ public class FriendServiceImpl implements FriendService {
 		return friendRepository.saveAll(friends).stream()
 			.map(savedFriend -> FriendAddResponse.ofEntity(savedFriend))
 			.collect(Collectors.toList());
+	}
+
+	@Override
+	public FriendStatusUpdateResponse updateFriendStatus(long myProfileId, long friendProfileId,
+		FriendStatusUpdateRequest request) {
+		// 1. find friend
+		Friend friend = friendRepository.findByMyProfileIdAndFriendProfileId(myProfileId, friendProfileId)
+			.orElseThrow(() -> new NotFoundException("friend", friendProfileId));
+
+		// 2. update
+		friend.updateStatus(request.getStatus());
+
+		// 3. save & return
+		friendRepository.save(friend);
+		return FriendStatusUpdateResponse.ofEntity(friend);
 	}
 }

--- a/src/test/java/com/avalon/avalonchat/domain/friend/repository/FriendRepositoryTest.java
+++ b/src/test/java/com/avalon/avalonchat/domain/friend/repository/FriendRepositoryTest.java
@@ -113,4 +113,31 @@ class FriendRepositoryTest {
 		// then
 		assertThat(findFriends.size()).isEqualTo(10);
 	}
+
+	@Test
+	void myProfileId와_friendProfileId로_친구찾기성공() {
+		// given - ready for users & profiles
+		User myUser = new User(Email.of("myUser@gmail.com"), Password.of("myPassword"));
+		Profile myProfile = new Profile(myUser, "myBio", LocalDate.now(), "myProfile", "01012345678");
+
+		User friendUser = new User(Email.of("friendUser@gmail.com"), Password.of("friendPassword"));
+		Profile friendProfile = new Profile(friendUser, "friendBio", LocalDate.now(), "friendNickname", "01012123434");
+
+		userRepository.save(myUser);
+		userRepository.save(friendUser);
+		Profile savedMyProfile = profileRepository.save(myProfile);
+		Profile savedFriendProfile = profileRepository.save(friendProfile);
+
+		// given - ready for friend
+		Friend friend = new Friend(savedMyProfile, savedFriendProfile);
+		friendRepository.save(friend);
+
+		// when
+		Friend foundFriend = friendRepository.findByMyProfileIdAndFriendProfileId(savedMyProfile.getId(),
+			savedFriendProfile.getId()).get();
+
+		// then
+		assertThat(foundFriend.getMyProfile().getId()).isEqualTo(savedMyProfile.getId());
+		assertThat(foundFriend.getFriendProfile().getId()).isEqualTo(savedFriendProfile.getId());
+	}
 }

--- a/src/test/java/com/avalon/avalonchat/domain/profile/service/ProfileServiceImplTest.java
+++ b/src/test/java/com/avalon/avalonchat/domain/profile/service/ProfileServiceImplTest.java
@@ -34,6 +34,7 @@ import com.avalon.avalonchat.domain.user.service.MessageService;
 import com.avalon.avalonchat.domain.user.service.UserService;
 import com.avalon.avalonchat.global.error.exception.BadRequestException;
 import com.avalon.avalonchat.testsupport.base.BaseTestContainerTest;
+
 @Transactional
 @SpringBootTest
 class ProfileServiceImplTest extends BaseTestContainerTest {


### PR DESCRIPTION
## Summary

*친구 상태 변경*

## (Optional): Description

*현재 로그인된 사용자의 개별 친구 상태 변경 API 구현*

## How Has This Been Tested?

*`myProfileId`, `FriendProfileId`를 통해 `Friend` 엔티티 조회용 레포지토리 메서드 테스트*
*친구 상태 변경 서비스 코드 테스트*
