### PR TITLE
어노테이션 작성 일관성, 프로필/이미지 생성 로직, DTO 작성 일관성 리팩토링

### DIFF
--- a/src/main/java/com/avalon/avalonchat/domain/chat/domain/ChatMessage.java
+++ b/src/main/java/com/avalon/avalonchat/domain/chat/domain/ChatMessage.java
@@ -42,16 +42,4 @@ public class ChatMessage {
 	@PersistenceCreator
 	public ChatMessage() {
 	}
-
-	@Override
-	public String toString() {
-		final StringBuilder sb = new StringBuilder("ChatMessage{");
-		sb.append("id='").append(id).append('\'');
-		sb.append(", senderId=").append(senderId);
-		sb.append(", chatRoomId='").append(chatRoomId).append('\'');
-		sb.append(", content='").append(content).append('\'');
-		sb.append(", createdAt=").append(createdAt);
-		sb.append('}');
-		return sb.toString();
-	}
 }

--- a/src/main/java/com/avalon/avalonchat/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/avalon/avalonchat/domain/friend/controller/FriendController.java
@@ -17,18 +17,20 @@ import com.avalon.avalonchat.domain.model.SecurityUser;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-@RestController
-@RequiredArgsConstructor
 @Slf4j
+@RequiredArgsConstructor
+@Tag(name = "친구 API", description = "WIP")
 @RequestMapping("/friends")
+@RestController
 public class FriendController {
 	private final FriendService friendService;
 
 	@Operation(
-		summary = "친구 추가",
+		summary = "[WIP] 친구 추가",
 		description = "phoneNumbers 를 이용하여 friend 레코드를 추가합니다.",
 		security = {@SecurityRequirement(name = "bearer-key")}
 	)

--- a/src/main/java/com/avalon/avalonchat/domain/friend/domain/Friend.java
+++ b/src/main/java/com/avalon/avalonchat/domain/friend/domain/Friend.java
@@ -1,9 +1,12 @@
 package com.avalon.avalonchat.domain.friend.domain;
 
+import static com.avalon.avalonchat.global.util.Preconditions.*;
+import static javax.persistence.EnumType.*;
+import static javax.persistence.FetchType.*;
+import static lombok.AccessLevel.*;
+
 import javax.persistence.Entity;
-import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
-import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToOne;
@@ -11,32 +14,40 @@ import javax.persistence.OneToOne;
 import com.avalon.avalonchat.domain.model.BaseAuditingEntity;
 import com.avalon.avalonchat.domain.profile.domain.Profile;
 
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Entity
+/**
+ * 친구 (친구 관계)
+ * - 현재 사용자 (myProfile) 과 친구 사용자 (friendProfile) 의 관계를 의미한다.
+ * - A -> B 관계가 B -> A 관계를 의미하지 않는다.
+ */
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = PROTECTED)
+@Entity
 public class Friend extends BaseAuditingEntity {
-	@ManyToOne(fetch = FetchType.LAZY)
+	@ManyToOne(fetch = LAZY)
 	@JoinColumn(name = "myProfileId")
 	private Profile myProfile;
 
-	@OneToOne(fetch = FetchType.LAZY)
+	@OneToOne(fetch = LAZY)
 	@JoinColumn(name = "friendProfileId")
 	private Profile friendProfile;
 
-	@Enumerated(EnumType.STRING)
-	private FriendStatus friendStatus = FriendStatus.NORMAL;
+	@Enumerated(STRING)
+	private Status status;
 
 	public Friend(Profile myProfile, Profile friendProfile) {
+		checkNotNull(myProfile, "Friend.myProfile cannot be null");
+		checkNotNull(myProfile, "Friend.friendProfile cannot be null");
+
 		this.myProfile = myProfile;
 		this.friendProfile = friendProfile;
+		this.status = Status.NORMAL;
 	}
 
-	/* 친구상태 종류 */
-	public enum FriendStatus {
+	/* 친구 상태*/
+	public enum Status {
 		NORMAL,
 		FAVORITES,
 		BLOCKED,

--- a/src/main/java/com/avalon/avalonchat/domain/friend/dto/FriendAddRequest.java
+++ b/src/main/java/com/avalon/avalonchat/domain/friend/dto/FriendAddRequest.java
@@ -3,14 +3,14 @@ package com.avalon.avalonchat.domain.friend.dto;
 import java.util.List;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Getter;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
-@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
 public class FriendAddRequest {
 	@Schema(description = "핸드폰 번호 리스트", example = "[010-1234-5678, 010-1212-3434]")
-	private final List<String> phoneNumbers;
-
-	public FriendAddRequest(List<String> phoneNumbers) {
-		this.phoneNumbers = phoneNumbers;
-	}
+	private List<String> phoneNumbers;
 }

--- a/src/main/java/com/avalon/avalonchat/domain/friend/dto/FriendAddResponse.java
+++ b/src/main/java/com/avalon/avalonchat/domain/friend/dto/FriendAddResponse.java
@@ -7,31 +7,35 @@ import com.avalon.avalonchat.domain.friend.domain.Friend;
 import com.avalon.avalonchat.domain.profile.domain.BackgroundImage;
 import com.avalon.avalonchat.domain.profile.domain.ProfileImage;
 
-import lombok.Getter;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
-@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
 public class FriendAddResponse {
-	private final long friendProfileId;
-	private final String nickname;
-	private final String bio;
-	private final List<String> profileImages;
-	private final List<String> backgroundImages;
-	private final Friend.FriendStatus friendStatus;
+	private long friendProfileId;
+	private String nickname;
+	private String bio;
+	private List<String> profileImages;
+	private List<String> backgroundImages;
+	private Friend.Status status;
 
-	public FriendAddResponse(Friend friend) {
-		this.friendProfileId = friend.getFriendProfile().getId();
-		this.nickname = friend.getFriendProfile().getNickname();
-		this.bio = friend.getFriendProfile().getBio();
-		this.profileImages = friend.getFriendProfile().getProfileImages().stream()
-			.map(ProfileImage::getUrl)
-			.collect(Collectors.toList());
-		this.backgroundImages = friend.getFriendProfile().getBackgroundImages().stream()
-			.map(BackgroundImage::getUrl)
-			.collect(Collectors.toList());
-		this.friendStatus = friend.getFriendStatus();
-	}
-
-	public static FriendAddResponse ofEntity(Friend friend) {
-		return new FriendAddResponse(friend);
+	// TODO - resolve n+1 problem,
+	// Q - do we really need all image links for added friends?
+	public static FriendAddResponse from(Friend friend) {
+		return new FriendAddResponse(
+			friend.getFriendProfile().getId(),
+			friend.getFriendProfile().getNickname(),
+			friend.getFriendProfile().getBio(),
+			friend.getFriendProfile().getProfileImages().stream()
+				.map(ProfileImage::getUrl)
+				.collect(Collectors.toList()),
+			friend.getFriendProfile().getBackgroundImages().stream()
+				.map(BackgroundImage::getUrl)
+				.collect(Collectors.toList()),
+			friend.getStatus()
+		);
 	}
 }

--- a/src/main/java/com/avalon/avalonchat/domain/friend/service/FriendService.java
+++ b/src/main/java/com/avalon/avalonchat/domain/friend/service/FriendService.java
@@ -6,5 +6,14 @@ import com.avalon.avalonchat.domain.friend.dto.FriendAddRequest;
 import com.avalon.avalonchat.domain.friend.dto.FriendAddResponse;
 
 public interface FriendService {
-	List<FriendAddResponse> addFriend(long id, FriendAddRequest request);
+
+	/**
+	 * add friends by given request(phonenumber list)
+	 *
+	 * @param profileId - current user profileId
+	 * @param request   - phonenumber list
+	 * @return - added Friend profiles
+	 */
+	// TODO - do not response List as Response
+	List<FriendAddResponse> addFriend(long profileId, FriendAddRequest request);
 }

--- a/src/main/java/com/avalon/avalonchat/domain/friend/service/FriendServiceImpl.java
+++ b/src/main/java/com/avalon/avalonchat/domain/friend/service/FriendServiceImpl.java
@@ -16,9 +16,9 @@ import com.avalon.avalonchat.global.error.exception.NotFoundException;
 
 import lombok.RequiredArgsConstructor;
 
-@Service
-@Transactional(readOnly = true)
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
 public class FriendServiceImpl implements FriendService {
 
 	private final FriendRepository friendRepository;
@@ -37,7 +37,7 @@ public class FriendServiceImpl implements FriendService {
 
 		// 2. save them & return
 		return friendRepository.saveAll(friends).stream()
-			.map(savedFriend -> FriendAddResponse.ofEntity(savedFriend))
+			.map(FriendAddResponse::from)
 			.collect(Collectors.toList());
 	}
 }

--- a/src/main/java/com/avalon/avalonchat/domain/login/controller/LoginController.java
+++ b/src/main/java/com/avalon/avalonchat/domain/login/controller/LoginController.java
@@ -14,7 +14,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
-@Tag(name = "login", description = "로그인과 관련된 endpoint 모음")
+@Tag(name = "login")
 @RequestMapping("/login")
 @RestController
 public class LoginController {

--- a/src/main/java/com/avalon/avalonchat/domain/login/service/LoginServiceImpl.java
+++ b/src/main/java/com/avalon/avalonchat/domain/login/service/LoginServiceImpl.java
@@ -13,10 +13,10 @@ import com.avalon.avalonchat.global.error.exception.BadRequestException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 @Service
-@Slf4j
 public class LoginServiceImpl implements LoginService {
 
 	private final UserRepository userRepository;
@@ -27,7 +27,7 @@ public class LoginServiceImpl implements LoginService {
 	@Override
 	public LoginResponse login(LoginRequest request) {
 		// 1. check user exists
-		final User findUser = userRepository.findByEmail(request.getEmail())
+		User findUser = userRepository.findByEmail(request.getEmail())
 			.orElseThrow(() -> new BadRequestException("login-failed.email.notfound", request.getEmail()));
 
 		// 2. verify password
@@ -37,7 +37,7 @@ public class LoginServiceImpl implements LoginService {
 
 		// 3. jwt token create
 		long profileId = getProfileIdService.getProfileIdByUserId(findUser.getId());
-		final String accessToken = tokenService.createAccessToken(findUser, profileId);
+		String accessToken = tokenService.createAccessToken(findUser, profileId);
 		return new LoginResponse(findUser.getEmail(), accessToken);
 	}
 }

--- a/src/main/java/com/avalon/avalonchat/domain/model/BaseIdEntity.java
+++ b/src/main/java/com/avalon/avalonchat/domain/model/BaseIdEntity.java
@@ -3,13 +3,11 @@ package com.avalon.avalonchat.domain.model;
 import static javax.persistence.GenerationType.*;
 
 import javax.persistence.Column;
-import javax.persistence.EntityListeners;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.MappedSuperclass;
 
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 /**
@@ -17,8 +15,8 @@ import lombok.Getter;
  * 모든 id 필드를 가지는 엔티티의 MappedSuperclass
  */
 @Getter
+@EqualsAndHashCode
 @MappedSuperclass
-@EntityListeners(AuditingEntityListener.class)
 public abstract class BaseIdEntity {
 
 	@Id

--- a/src/main/java/com/avalon/avalonchat/domain/model/SecurityUser.java
+++ b/src/main/java/com/avalon/avalonchat/domain/model/SecurityUser.java
@@ -3,6 +3,9 @@ package com.avalon.avalonchat.domain.model;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+/**
+ * a principal of authenticated SecurityContext
+ */
 @Getter
 @RequiredArgsConstructor
 public class SecurityUser {

--- a/src/main/java/com/avalon/avalonchat/domain/profile/controller/ProfileController.java
+++ b/src/main/java/com/avalon/avalonchat/domain/profile/controller/ProfileController.java
@@ -22,13 +22,15 @@ import com.avalon.avalonchat.domain.profile.service.ProfileService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-@RestController
-@RequiredArgsConstructor
 @Slf4j
+@RequiredArgsConstructor
+@Tag(name = "프로필 API")
 @RequestMapping("/profiles")
+@RestController
 public class ProfileController {
 
 	private final ProfileService service;

--- a/src/main/java/com/avalon/avalonchat/domain/profile/domain/BackgroundImage.java
+++ b/src/main/java/com/avalon/avalonchat/domain/profile/domain/BackgroundImage.java
@@ -1,32 +1,35 @@
 package com.avalon.avalonchat.domain.profile.domain;
 
+import static com.avalon.avalonchat.global.util.Preconditions.*;
+import static javax.persistence.FetchType.*;
+import static lombok.AccessLevel.*;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 
 import com.avalon.avalonchat.domain.model.BaseAuditingEntity;
 
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
-@Entity
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = PROTECTED)
+@Entity
 public class BackgroundImage extends BaseAuditingEntity {
 
-	@ManyToOne(fetch = FetchType.LAZY)
+	@ManyToOne(fetch = LAZY)
 	@JoinColumn(name = "profile_id")
-	@Setter
 	private Profile profile;
 
 	@Column
 	private String url;
 
-	public BackgroundImage(Profile profile, String url) {
+	BackgroundImage(Profile profile, String url) {
+		checkNotNull(profile, "BackgroundImage.profile cannot be null");
+		checkNotNull(profile, "BackgroundImage.url cannot be null");
+
 		this.profile = profile;
 		this.url = url;
 	}

--- a/src/main/java/com/avalon/avalonchat/domain/profile/domain/Profile.java
+++ b/src/main/java/com/avalon/avalonchat/domain/profile/domain/Profile.java
@@ -1,13 +1,15 @@
 package com.avalon.avalonchat.domain.profile.domain;
 
+import static javax.persistence.CascadeType.*;
+import static javax.persistence.FetchType.*;
+import static lombok.AccessLevel.*;
+
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
@@ -15,17 +17,15 @@ import javax.persistence.OneToOne;
 import com.avalon.avalonchat.domain.model.BaseAuditingEntity;
 import com.avalon.avalonchat.domain.user.domain.User;
 
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Entity
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = PROTECTED)
 public class Profile extends BaseAuditingEntity {
 
-	@OneToOne(fetch = FetchType.LAZY)
+	@OneToOne(fetch = LAZY)
 	@JoinColumn(name = "users_id", unique = true)
 	private User user;
 
@@ -39,15 +39,15 @@ public class Profile extends BaseAuditingEntity {
 	private String nickname;
 
 	@Column
-	@Setter
 	private String phoneNumber;
 
-	@OneToMany(mappedBy = "profile", cascade = CascadeType.PERSIST, orphanRemoval = true)
+	@OneToMany(mappedBy = "profile", cascade = ALL, orphanRemoval = true)
 	private List<ProfileImage> profileImages = new ArrayList<>();
 
-	@OneToMany(mappedBy = "profile", cascade = CascadeType.PERSIST, orphanRemoval = true)
+	@OneToMany(mappedBy = "profile", cascade = ALL, orphanRemoval = true)
 	private List<BackgroundImage> backgroundImages = new ArrayList<>();
 
+	// TODO - 처음 생성자에서 profileImageUrl 과 backgroundImageUrl 을 받아도 되지 않을까?
 	public Profile(User user, String bio, LocalDate birthDate, String nickname, String phoneNumber) {
 		this.user = user;
 		this.bio = bio;
@@ -56,13 +56,13 @@ public class Profile extends BaseAuditingEntity {
 		this.phoneNumber = phoneNumber;
 	}
 
-	public void addProfileImage(ProfileImage profileImage) {
+	public void addProfileImage(String profileImageUrl) {
+		ProfileImage profileImage = new ProfileImage(this, profileImageUrl);
 		profileImages.add(profileImage);
-		profileImage.setProfile(this);
 	}
 
-	public void addBackgroundImage(BackgroundImage backgroundImage) {
+	public void addBackgroundImage(String backgroundImageUrl) {
+		BackgroundImage backgroundImage = new BackgroundImage(this, backgroundImageUrl);
 		backgroundImages.add(backgroundImage);
-		backgroundImage.setProfile(this);
 	}
 }

--- a/src/main/java/com/avalon/avalonchat/domain/profile/domain/ProfileImage.java
+++ b/src/main/java/com/avalon/avalonchat/domain/profile/domain/ProfileImage.java
@@ -1,5 +1,8 @@
 package com.avalon.avalonchat.domain.profile.domain;
 
+import static com.avalon.avalonchat.global.util.Preconditions.*;
+import static lombok.AccessLevel.*;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -8,25 +11,25 @@ import javax.persistence.ManyToOne;
 
 import com.avalon.avalonchat.domain.model.BaseAuditingEntity;
 
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
-@Entity
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = PROTECTED)
+@Entity
 public class ProfileImage extends BaseAuditingEntity {
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "profile_id")
-	@Setter
 	private Profile profile;
 
 	@Column
 	private String url;
 
-	public ProfileImage(Profile profile, String url) {
+	ProfileImage(Profile profile, String url) {
+		checkNotNull(profile, "ProfileImage.profile cannot be null");
+		checkNotNull(profile, "ProfileImage.url cannot be null");
+
 		this.profile = profile;
 		this.url = url;
 	}

--- a/src/main/java/com/avalon/avalonchat/domain/profile/dto/ProfileAddRequest.java
+++ b/src/main/java/com/avalon/avalonchat/domain/profile/dto/ProfileAddRequest.java
@@ -5,44 +5,32 @@ import java.time.LocalDate;
 import javax.validation.constraints.NotNull;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Getter;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
-@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
 public class ProfileAddRequest {
 
 	@NotNull
 	@Schema(description = "생년월일", example = "2000.01.01")
-	private final LocalDate birthDate;
+	private LocalDate birthDate;
 
 	@NotNull
 	@Schema(description = "닉네임", example = "nickName")
-	private final String nickname;
+	private String nickname;
 
 	@Schema(description = "상태 메시지", example = "hi there")
-	private final String bio;
+	private String bio;
 
 	@Schema(description = "프로필 이미지 주소", example = "http://profile/image/url")
-	private final String profileImageUrl;
+	private String profileImageUrl;
 
 	@Schema(description = "배경 이미지 주소", example = "http://background/image/url")
-	private final String backgroundImageUrl;
+	private String backgroundImageUrl;
 
 	@Schema(description = "핸드폰 번호", example = "010-1234-5678")
-	private final String phoneNumber;
-
-	public ProfileAddRequest(
-		LocalDate birthDate,
-		String nickname,
-		String bio,
-		String profileImageUrl,
-		String backgroundImageUrl,
-		String phoneNumber
-	) {
-		this.birthDate = birthDate;
-		this.nickname = nickname;
-		this.bio = bio;
-		this.profileImageUrl = profileImageUrl;
-		this.backgroundImageUrl = backgroundImageUrl;
-		this.phoneNumber = phoneNumber;
-	}
+	private String phoneNumber;
 }

--- a/src/main/java/com/avalon/avalonchat/domain/profile/dto/ProfileAddResponse.java
+++ b/src/main/java/com/avalon/avalonchat/domain/profile/dto/ProfileAddResponse.java
@@ -8,33 +8,22 @@ import com.avalon.avalonchat.domain.profile.domain.BackgroundImage;
 import com.avalon.avalonchat.domain.profile.domain.Profile;
 import com.avalon.avalonchat.domain.profile.domain.ProfileImage;
 
-import lombok.Getter;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
-@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
 public class ProfileAddResponse {
-	private final LocalDate birthDate;
-	private final String nickname;
-	private final String bio;
-	private final List<String> profileImages;
-	private final List<String> backgroundImages;
-	private final String phoneNumber;
+	private LocalDate birthDate;
+	private String nickname;
+	private String bio;
+	private List<String> profileImages;
+	private List<String> backgroundImages;
+	private String phoneNumber;
 
-	public ProfileAddResponse(
-		LocalDate birthDate,
-		String nickname,
-		String bio,
-		List<String> profileImages,
-		List<String> backgroundImages,
-		String phoneNumber) {
-		this.birthDate = birthDate;
-		this.nickname = nickname;
-		this.bio = bio;
-		this.profileImages = profileImages;
-		this.backgroundImages = backgroundImages;
-		this.phoneNumber = phoneNumber;
-	}
-
-	public static ProfileAddResponse ofEntity(Profile profile) {
+	public static ProfileAddResponse from(Profile profile) {
 		return new ProfileAddResponse(
 			profile.getBirthDate(),
 			profile.getNickname(),

--- a/src/main/java/com/avalon/avalonchat/domain/profile/dto/ProfileDetailedGetResponse.java
+++ b/src/main/java/com/avalon/avalonchat/domain/profile/dto/ProfileDetailedGetResponse.java
@@ -4,8 +4,10 @@ import com.avalon.avalonchat.domain.profile.domain.Profile;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @AllArgsConstructor
+@NoArgsConstructor
 @Data
 public class ProfileDetailedGetResponse {
 

--- a/src/main/java/com/avalon/avalonchat/domain/profile/dto/ProfileListGetResponse.java
+++ b/src/main/java/com/avalon/avalonchat/domain/profile/dto/ProfileListGetResponse.java
@@ -1,16 +1,14 @@
 package com.avalon.avalonchat.domain.profile.dto;
 
-import lombok.Getter;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
-@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
 public class ProfileListGetResponse {
-	private final String nickname;
-	private final String bio;
-	private final String profileImageUrl;
-
-	public ProfileListGetResponse(String nickname, String bio, String profileImageUrl) {
-		this.nickname = nickname;
-		this.bio = bio;
-		this.profileImageUrl = profileImageUrl;
-	}
+	private String nickname;
+	private String bio;
+	private String profileImageUrl;
 }

--- a/src/main/java/com/avalon/avalonchat/domain/profile/service/ProfileServiceImpl.java
+++ b/src/main/java/com/avalon/avalonchat/domain/profile/service/ProfileServiceImpl.java
@@ -6,9 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.avalon.avalonchat.domain.login.service.GetProfileIdService;
-import com.avalon.avalonchat.domain.profile.domain.BackgroundImage;
 import com.avalon.avalonchat.domain.profile.domain.Profile;
-import com.avalon.avalonchat.domain.profile.domain.ProfileImage;
 import com.avalon.avalonchat.domain.profile.dto.ProfileAddRequest;
 import com.avalon.avalonchat.domain.profile.dto.ProfileAddResponse;
 import com.avalon.avalonchat.domain.profile.dto.ProfileDetailedGetResponse;
@@ -56,14 +54,14 @@ public class ProfileServiceImpl
 		);
 
 		// 4. create images & add to profile
-		profile.addProfileImage(new ProfileImage(profile, request.getProfileImageUrl()));
-		profile.addBackgroundImage(new BackgroundImage(profile, request.getBackgroundImageUrl()));
+		profile.addProfileImage(request.getProfileImageUrl());
+		profile.addBackgroundImage(request.getBackgroundImageUrl());
 
 		// 5. save it
 		repository.save(profile);
 
 		// 6. return
-		return ProfileAddResponse.ofEntity(profile);
+		return ProfileAddResponse.from(profile);
 	}
 
 	@Override

--- a/src/main/java/com/avalon/avalonchat/domain/user/domain/Email.java
+++ b/src/main/java/com/avalon/avalonchat/domain/user/domain/Email.java
@@ -1,26 +1,25 @@
 package com.avalon.avalonchat.domain.user.domain;
 
 import static com.avalon.avalonchat.global.util.Preconditions.*;
+import static lombok.AccessLevel.*;
 
 import java.util.regex.Pattern;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 
-import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EqualsAndHashCode
 @Getter
+@NoArgsConstructor(access = PROTECTED)
+@EqualsAndHashCode
 @Embeddable
 public class Email {
 
 	/* EMAIL_PATTERN - RFC 5322 */
-	private static final Pattern EMAIL_PATTERN =
-		Pattern.compile("^[a-zA-Z0-9_!#$%&'*+/=?`{|}~^.-]+@[a-zA-Z0-9.-]+$");
+	private static final Pattern EMAIL_PATTERN = Pattern.compile("^[a-zA-Z0-9_!#$%&'*+/=?`{|}~^.-]+@[a-zA-Z0-9.-]+$");
 
 	@Column(name = "email", unique = true, nullable = false)
 	private String value;

--- a/src/main/java/com/avalon/avalonchat/domain/user/domain/Password.java
+++ b/src/main/java/com/avalon/avalonchat/domain/user/domain/Password.java
@@ -1,18 +1,18 @@
 package com.avalon.avalonchat.domain.user.domain;
 
 import static com.avalon.avalonchat.global.util.Preconditions.*;
+import static lombok.AccessLevel.*;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 
-import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EqualsAndHashCode
 @Getter
+@NoArgsConstructor(access = PROTECTED)
+@EqualsAndHashCode
 @Embeddable
 public class Password {
 	public static final int MIN_LENGTH = 7;

--- a/src/main/java/com/avalon/avalonchat/domain/user/domain/User.java
+++ b/src/main/java/com/avalon/avalonchat/domain/user/domain/User.java
@@ -1,19 +1,21 @@
 package com.avalon.avalonchat.domain.user.domain;
 
+import static com.avalon.avalonchat.global.util.Preconditions.*;
+import static lombok.AccessLevel.*;
+
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.Table;
 
 import com.avalon.avalonchat.domain.model.BaseAuditingEntity;
 
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Entity
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = PROTECTED)
 @Table(name = "users")
+@Entity
 public class User extends BaseAuditingEntity {
 
 	@Embedded
@@ -23,6 +25,9 @@ public class User extends BaseAuditingEntity {
 	private Password password;
 
 	public User(Email email, Password password) {
+		checkNotNull(email, "User.email cannot be null");
+		checkNotNull(password, "User.password cannot be null");
+
 		this.email = email;
 		this.password = password;
 	}

--- a/src/main/java/com/avalon/avalonchat/global/configuration/jwt/JwtConfigProperties.java
+++ b/src/main/java/com/avalon/avalonchat/global/configuration/jwt/JwtConfigProperties.java
@@ -1,22 +1,22 @@
 package com.avalon.avalonchat.global.configuration.jwt;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.boot.context.properties.ConstructorBinding;
 
 import lombok.Getter;
-import lombok.Setter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
-@Setter
+@RequiredArgsConstructor
+@ConstructorBinding
 @ConfigurationProperties(prefix = "jwt")
-@Configuration
 public class JwtConfigProperties {
 
 	// access token validity in millis
-	private int accessValidity;
+	private final int accessValidity;
 
 	// refresh token validity in millis
-	private int refreshValidity;
+	private final int refreshValidity;
 
-	private String secret;
+	private final String secret;
 }

--- a/src/main/java/com/avalon/avalonchat/global/configuration/message/CoolSmsProperties.java
+++ b/src/main/java/com/avalon/avalonchat/global/configuration/message/CoolSmsProperties.java
@@ -5,9 +5,9 @@ import org.springframework.boot.context.properties.ConstructorBinding;
 
 import lombok.Getter;
 
-@ConfigurationProperties(prefix = "cool-sms")
-@ConstructorBinding
 @Getter
+@ConstructorBinding
+@ConfigurationProperties(prefix = "cool-sms")
 public class CoolSmsProperties {
 	private final String apiKey;
 	private final String apiSecret;

--- a/src/test/java/com/avalon/avalonchat/domain/friend/domain/FriendTest.java
+++ b/src/test/java/com/avalon/avalonchat/domain/friend/domain/FriendTest.java
@@ -29,7 +29,7 @@ class FriendTest {
 		//then
 		assertThat(friend.getMyProfile()).isEqualTo(myProfile);
 		assertThat(friend.getFriendProfile()).isEqualTo(friendProfile);
-		assertThat(friend.getFriendStatus()).isEqualTo(Friend.FriendStatus.NORMAL);
+		assertThat(friend.getStatus()).isEqualTo(Friend.Status.NORMAL);
 	}
 
 }

--- a/src/test/java/com/avalon/avalonchat/domain/friend/service/FriendServiceImplTest.java
+++ b/src/test/java/com/avalon/avalonchat/domain/friend/service/FriendServiceImplTest.java
@@ -25,6 +25,7 @@ import com.avalon.avalonchat.domain.user.domain.Password;
 import com.avalon.avalonchat.domain.user.domain.User;
 import com.avalon.avalonchat.domain.user.repository.UserRepository;
 
+@Transactional
 @SpringBootTest
 class FriendServiceImplTest {
 	@Autowired

--- a/src/test/java/com/avalon/avalonchat/domain/friend/service/FriendServiceImplTest.java
+++ b/src/test/java/com/avalon/avalonchat/domain/friend/service/FriendServiceImplTest.java
@@ -1,10 +1,8 @@
 package com.avalon.avalonchat.domain.friend.service;
 
+import static java.time.LocalDate.*;
 import static org.assertj.core.api.AssertionsForClassTypes.*;
 
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -16,9 +14,7 @@ import com.avalon.avalonchat.domain.friend.domain.Friend;
 import com.avalon.avalonchat.domain.friend.dto.FriendAddRequest;
 import com.avalon.avalonchat.domain.friend.dto.FriendAddResponse;
 import com.avalon.avalonchat.domain.friend.repository.FriendRepository;
-import com.avalon.avalonchat.domain.profile.domain.BackgroundImage;
 import com.avalon.avalonchat.domain.profile.domain.Profile;
-import com.avalon.avalonchat.domain.profile.domain.ProfileImage;
 import com.avalon.avalonchat.domain.profile.repository.ProfileRepository;
 import com.avalon.avalonchat.domain.user.domain.Email;
 import com.avalon.avalonchat.domain.user.domain.Password;
@@ -40,12 +36,7 @@ class FriendServiceImplTest {
 	@Transactional
 	void 친구추가_성공() {
 		// given
-		String phoneNumber1 = "010-1234-5678";
-		String phoneNumber2 = "010-8765-4321";
-		List<String> phoneNumbers = new ArrayList<>();
-		phoneNumbers.add(phoneNumber1);
-		phoneNumbers.add(phoneNumber2);
-		FriendAddRequest request = new FriendAddRequest(phoneNumbers);
+		FriendAddRequest request = new FriendAddRequest(List.of("010-1234-5678", "010-8765-4321"));
 
 		User myUser = new User(Email.of("myuser@gmail.com"), Password.of("password"));
 		User friendUser1 = new User(Email.of("frienduser1@gmail.com"), Password.of("password1"));
@@ -55,28 +46,19 @@ class FriendServiceImplTest {
 		User savedFriendUser1 = userRepository.save(friendUser1);
 		User savedFriendUser2 = userRepository.save(friendUser2);
 
-		String phoneNumber = "01055110625";
-
-		Profile myProfile = new Profile(savedMyUser, "bio", LocalDate.now(), "nickname", phoneNumber);
-		Profile friendProfile1 = new Profile(savedFriendUser1, "bio1", LocalDate.now(), "nickname1", phoneNumber);
-		Profile friendProfile2 = new Profile(savedFriendUser2, "bio2", LocalDate.now(), "nickname2", phoneNumber);
-		friendProfile1.setPhoneNumber(phoneNumber1);
-		friendProfile2.setPhoneNumber(phoneNumber2);
+		Profile myProfile = new Profile(savedMyUser, "bio", now(), "myuser", "010-5511-0625");
+		Profile friendProfile1 = new Profile(savedFriendUser1, "bio1", now(), "frienduser1", "010-1234-5678");
+		Profile friendProfile2 = new Profile(savedFriendUser2, "bio2", now(), "frienduser2", "010-8765-4321");
 
 		String friendProfileUrl1 = "storage/url/profile_image1.png";
 		String friendProfileUrl2 = "storage/url/profile_image2.png";
 		String friendBackgroundUrl1 = "storage/url/background_image1.png";
 		String friendBackgroundUrl2 = "storage/url/background_image2.png";
 
-		ProfileImage friendProfileImage1 = new ProfileImage(friendProfile1, friendProfileUrl1);
-		ProfileImage friendProfileImage2 = new ProfileImage(friendProfile2, friendProfileUrl2);
-		BackgroundImage friendBackgroundImage1 = new BackgroundImage(friendProfile1, friendBackgroundUrl1);
-		BackgroundImage friendBackgroundImage2 = new BackgroundImage(friendProfile2, friendBackgroundUrl2);
-
-		friendProfile1.addProfileImage(friendProfileImage1);
-		friendProfile1.addBackgroundImage(friendBackgroundImage1);
-		friendProfile2.addProfileImage(friendProfileImage2);
-		friendProfile2.addBackgroundImage(friendBackgroundImage2);
+		friendProfile1.addProfileImage("storage/url/profile_image1.png");
+		friendProfile1.addBackgroundImage("storage/url/background_image1.png");
+		friendProfile2.addProfileImage("storage/url/profile_image2.png");
+		friendProfile2.addBackgroundImage("storage/url/background_image2.png");
 
 		Profile savedMyProfile = profileRepository.save(myProfile);
 		profileRepository.save(friendProfile1);
@@ -87,15 +69,12 @@ class FriendServiceImplTest {
 
 		// then
 		for (FriendAddResponse response : responses) {
-			assertThat(response.getFriendProfileId()).isIn(
-				Arrays.asList(friendProfile1.getId(), friendProfile2.getId()));
-			assertThat(response.getNickname()).isIn(
-				Arrays.asList(friendProfile1.getNickname(), friendProfile2.getNickname()));
-			assertThat(response.getBio()).isIn(Arrays.asList(friendProfile1.getBio(), friendProfile2.getBio()));
-			assertThat(response.getProfileImages().get(0)).isIn(Arrays.asList(friendProfileUrl1, friendProfileUrl2));
-			assertThat(response.getBackgroundImages().get(0)).isIn(
-				Arrays.asList(friendBackgroundUrl1, friendBackgroundUrl2));
-			assertThat(response.getFriendStatus()).isEqualTo(Friend.FriendStatus.NORMAL);
+			assertThat(response.getFriendProfileId()).isIn(friendProfile1.getId(), friendProfile2.getId());
+			assertThat(response.getNickname()).isIn(friendProfile1.getNickname(), friendProfile2.getNickname());
+			assertThat(response.getBio()).isIn(friendProfile1.getBio(), friendProfile2.getBio());
+			assertThat(response.getProfileImages().get(0)).isIn(friendProfileUrl1, friendProfileUrl2);
+			assertThat(response.getBackgroundImages().get(0)).isIn(friendBackgroundUrl1, friendBackgroundUrl2);
+			assertThat(response.getStatus()).isEqualTo(Friend.Status.NORMAL);
 		}
 	}
 }

--- a/src/test/java/com/avalon/avalonchat/domain/profile/domain/ProfileTest.java
+++ b/src/test/java/com/avalon/avalonchat/domain/profile/domain/ProfileTest.java
@@ -1,38 +1,31 @@
 package com.avalon.avalonchat.domain.profile.domain;
 
+import static com.avalon.avalonchat.testsupport.Fixture.*;
 import static org.assertj.core.api.AssertionsForClassTypes.*;
 
 import java.time.LocalDate;
 
 import org.junit.jupiter.api.Test;
 
-import com.avalon.avalonchat.domain.user.domain.Email;
-import com.avalon.avalonchat.domain.user.domain.Password;
 import com.avalon.avalonchat.domain.user.domain.User;
 
 class ProfileTest {
 	@Test
 	void profile_생성성공() {
 		//given
-		User user = new User(Email.of("email@gmail.com"), Password.of("password"));
-
+		User user = createUser("email@gmail.com", "password");
 		String bio = "This is my bio";
 		LocalDate birthDate = LocalDate.now();
 		String nickname = "nickname";
-
 		String profileUrl = "storage/url/profile_image.png";
 		String backgroundUrl = "storage/url/background_image.png";
-
 		String phoneNumber = "01055110625";
 
 		// when
+		// TODO - 처음 생성자에서 profileImageUrl 과 backgroundImageUrl 을 받아도 되지 않을까?
 		Profile profile = new Profile(user, bio, birthDate, nickname, phoneNumber);
-
-		ProfileImage profileImage = new ProfileImage(profile, profileUrl);
-		BackgroundImage backgroundImage = new BackgroundImage(profile, backgroundUrl);
-
-		profile.addProfileImage(profileImage);
-		profile.addBackgroundImage(backgroundImage);
+		profile.addProfileImage("storage/url/profile_image.png");
+		profile.addBackgroundImage("storage/url/background_image.png");
 
 		//then
 		assertThat(profile.getUser()).isEqualTo(user);

--- a/src/test/java/com/avalon/avalonchat/domain/profile/repository/ProfileRepositoryTest.java
+++ b/src/test/java/com/avalon/avalonchat/domain/profile/repository/ProfileRepositoryTest.java
@@ -25,8 +25,8 @@ import com.avalon.avalonchat.domain.user.domain.Password;
 import com.avalon.avalonchat.domain.user.domain.User;
 import com.avalon.avalonchat.domain.user.repository.UserRepository;
 
-@DataJpaTest
 @Transactional
+@DataJpaTest
 class ProfileRepositoryTest {
 	@Autowired
 	private EntityManager em;

--- a/src/test/java/com/avalon/avalonchat/domain/profile/repository/ProfileRepositoryTest.java
+++ b/src/test/java/com/avalon/avalonchat/domain/profile/repository/ProfileRepositoryTest.java
@@ -1,10 +1,10 @@
 package com.avalon.avalonchat.domain.profile.repository;
 
 import static com.avalon.avalonchat.testsupport.Fixture.*;
-import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static java.time.LocalDate.*;
+import static org.assertj.core.api.Assertions.*;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.List;
 
 import javax.persistence.EntityManager;
@@ -31,7 +31,7 @@ class ProfileRepositoryTest {
 	@Autowired
 	private EntityManager em;
 	@Autowired
-	private ProfileRepository profileRepository;
+	private ProfileRepository sut;
 	@Autowired
 	private UserRepository userRepository;
 	@Autowired
@@ -44,25 +44,19 @@ class ProfileRepositoryTest {
 		userRepository.save(user);
 
 		String bio = "bio";
-		LocalDate birthDate = LocalDate.now();
+		LocalDate birthDate = now();
 		String nickname = "nickname";
-
-		String profileUrl = "storage/url/profile_image.png";
-		String backgroundUrl = "storage/url/background_image.png";
-
 		String phoneNumber = "01055110625";
 
 		Profile profile = new Profile(user, bio, birthDate, nickname, phoneNumber);
 
-		ProfileImage profileImage = new ProfileImage(profile, profileUrl);
-		BackgroundImage backgroundImage = new BackgroundImage(profile, backgroundUrl);
-
 		//when & then
-		profile.addProfileImage(profileImage);
-		profile.addBackgroundImage(backgroundImage);
+		profile.addProfileImage("storage/url/profile_image.png");
+		profile.addBackgroundImage("storage/url/background_image.png");
+		ProfileImage profileImage = profile.getProfileImages().get(0);
+		BackgroundImage backgroundImage = profile.getBackgroundImages().get(0);
 
 		em.persist(profile);
-
 		assertThat(em.contains(profile)).isTrue();
 		assertThat(em.contains(profileImage)).isTrue();
 		assertThat(em.contains(backgroundImage)).isTrue();
@@ -79,37 +73,17 @@ class ProfileRepositoryTest {
 	@Test
 	void findAllByPhoneNumber_조회성공() {
 		// given
-		String phoneNumber1 = "010-1234-5678";
-		String phoneNumber2 = "010-8765-4321";
-		List<String> phoneNumbers = new ArrayList<>();
-		phoneNumbers.add(phoneNumber1);
-		phoneNumbers.add(phoneNumber2);
-		String phoneNumber = "01055110625";
+		User user1 = userRepository.save(createUser("email@gmail1.com", "password1"));
+		User user2 = userRepository.save(createUser("email@gmail2.com", "password2"));
 
-		User myUser = new User(Email.of("email@gmail.com"), Password.of("password"));
-		User friendUser1 = new User(Email.of("email@gmail1.com"), Password.of("password1"));
-		User friendUser2 = new User(Email.of("email@gmail2.com"), Password.of("password2"));
-		User savedMyUser = userRepository.save(myUser);
-		User savedFriendUser1 = userRepository.save(friendUser1);
-		User savedFriendUser2 = userRepository.save(friendUser2);
-
-		Profile myProfile = new Profile(savedMyUser, "bio", LocalDate.now(), "nickname", phoneNumber);
-		Profile friendProfile1 = new Profile(savedFriendUser1, "bio1", LocalDate.now(), "nickname1", phoneNumber);
-		Profile friendProfile2 = new Profile(savedFriendUser2, "bio2", LocalDate.now(), "nickname2", phoneNumber);
-		friendProfile1.setPhoneNumber(phoneNumber1);
-		friendProfile2.setPhoneNumber(phoneNumber2);
-		profileRepository.save(myProfile);
-		profileRepository.save(friendProfile1);
-		profileRepository.save(friendProfile2);
-		List<Profile> profiles = new ArrayList<>();
-		profiles.add(friendProfile1);
-		profiles.add(friendProfile2);
+		Profile profile1 = sut.save(new Profile(user1, "bio1", now(), "nickname1", "010-1234-5678"));
+		Profile profile2 = sut.save(new Profile(user2, "bio2", now(), "nickname2", "010-8765-4321"));
 
 		// when
-		List<Profile> savedProfiles = profileRepository.findAllByPhoneNumberIn(phoneNumbers);
+		List<Profile> foundProfiles = sut.findAllByPhoneNumberIn(List.of("010-1234-5678", "010-8765-4321"));
 
 		// then
-		assertThat(savedProfiles.containsAll(profiles)).isTrue();
+		assertThat(foundProfiles).containsExactlyInAnyOrder(profile1, profile2);
 	}
 
 	@Test
@@ -124,25 +98,21 @@ class ProfileRepositoryTest {
 
 		// given - ready for profiles
 		Profile myProfile = createProfile(
-			myUser, "I'm myUser", LocalDate.of(1997, 8, 21), ",my", "01012345678"
+			myUser, "I'm myUser", of(1997, 8, 21), ",my", "01012345678"
 		);
 		Profile friendProfile1 = createProfile(
-			friendUser1, "I'm friend1", LocalDate.of(1998, 9, 22), "A_friend", "01012123434"
+			friendUser1, "I'm friend1", of(1998, 9, 22), "A_friend", "01012123434"
 		);
 		Profile friendProfile2 = createProfile(
-			friendUser2, "I'm friend2", LocalDate.of(1999, 10, 23), "B_friend", "01011112222"
+			friendUser2, "I'm friend2", of(1999, 10, 23), "B_friend", "01011112222"
 		);
-		ProfileImage profileImage1 = new ProfileImage(friendProfile1, "url1");
-		ProfileImage profileImage2 = new ProfileImage(friendProfile1, "url2");
-		ProfileImage profileImage3 = new ProfileImage(friendProfile2, "url3");
-		ProfileImage profileImage4 = new ProfileImage(friendProfile2, "url4");
-		friendProfile1.addProfileImage(profileImage1);
-		friendProfile1.addProfileImage(profileImage2);
-		friendProfile2.addProfileImage(profileImage3);
-		friendProfile2.addProfileImage(profileImage4);
-		Profile savedMyProfile = profileRepository.save(myProfile);
-		profileRepository.save(friendProfile1);
-		profileRepository.save(friendProfile2);
+		friendProfile1.addProfileImage("url1");
+		friendProfile1.addProfileImage("url2");
+		friendProfile2.addProfileImage("url3");
+		friendProfile2.addProfileImage("url4");
+		Profile savedMyProfile = sut.save(myProfile);
+		sut.save(friendProfile1);
+		sut.save(friendProfile2);
 
 		// given - ready for friends
 		Friend friend1 = new Friend(myProfile, friendProfile1);
@@ -151,7 +121,7 @@ class ProfileRepositoryTest {
 		friendRepository.save(friend2);
 
 		// when
-		List<ProfileListGetResponse> friendProfiles = profileRepository.findAllByMyProfileId(savedMyProfile.getId());
+		List<ProfileListGetResponse> friendProfiles = sut.findAllByMyProfileId(savedMyProfile.getId());
 
 		// then
 		assertThat(friendProfiles.size()).isEqualTo(2);

--- a/src/test/java/com/avalon/avalonchat/domain/profile/service/ProfileServiceImplTest.java
+++ b/src/test/java/com/avalon/avalonchat/domain/profile/service/ProfileServiceImplTest.java
@@ -17,7 +17,6 @@ import org.springframework.transaction.annotation.Transactional;
 import com.avalon.avalonchat.domain.friend.domain.Friend;
 import com.avalon.avalonchat.domain.friend.repository.FriendRepository;
 import com.avalon.avalonchat.domain.profile.domain.Profile;
-import com.avalon.avalonchat.domain.profile.domain.ProfileImage;
 import com.avalon.avalonchat.domain.profile.dto.ProfileAddRequest;
 import com.avalon.avalonchat.domain.profile.dto.ProfileAddResponse;
 import com.avalon.avalonchat.domain.profile.dto.ProfileDetailedGetResponse;
@@ -34,6 +33,7 @@ import com.avalon.avalonchat.domain.user.service.MessageService;
 import com.avalon.avalonchat.domain.user.service.UserService;
 import com.avalon.avalonchat.global.error.exception.BadRequestException;
 import com.avalon.avalonchat.testsupport.base.BaseTestContainerTest;
+
 @Transactional
 @SpringBootTest
 class ProfileServiceImplTest extends BaseTestContainerTest {
@@ -181,14 +181,10 @@ class ProfileServiceImplTest extends BaseTestContainerTest {
 		Profile friendProfile2 = createProfile(
 			friendUser2, "I'm friend2", LocalDate.of(1999, 10, 23), "B_friend", "01011112222"
 		);
-		ProfileImage profileImage1 = new ProfileImage(friendProfile1, "url1");
-		ProfileImage profileImage2 = new ProfileImage(friendProfile1, "url2");
-		ProfileImage profileImage3 = new ProfileImage(friendProfile2, "url3");
-		ProfileImage profileImage4 = new ProfileImage(friendProfile2, "url4");
-		friendProfile1.addProfileImage(profileImage1);
-		friendProfile1.addProfileImage(profileImage2);
-		friendProfile2.addProfileImage(profileImage3);
-		friendProfile2.addProfileImage(profileImage4);
+		friendProfile1.addProfileImage("url1");
+		friendProfile1.addProfileImage("url2");
+		friendProfile2.addProfileImage("url3");
+		friendProfile2.addProfileImage("url4");
 		Profile savedMyProfile = profileRepository.save(myProfile);
 		profileRepository.save(friendProfile1);
 		profileRepository.save(friendProfile2);

--- a/src/test/java/com/avalon/avalonchat/testsupport/Fixture.java
+++ b/src/test/java/com/avalon/avalonchat/testsupport/Fixture.java
@@ -20,8 +20,13 @@ public final class Fixture {
 		);
 	}
 
-	public static Profile createProfile(User user, String bio, LocalDate birthDate, String nickname,
-		String phoneNumber) {
+	public static Profile createProfile(
+		User user,
+		String bio,
+		LocalDate birthDate,
+		String nickname,
+		String phoneNumber
+	) {
 		return new Profile(
 			user,
 			bio,


### PR DESCRIPTION
## Summary

- 어노테이션 작성 일관성, 
- 프로필/이미지 생성 로직,
 - DTO 작성 일관성 리팩토링

## Description

- 어노테이션 작성 순서에 어느정도 일관성을 주고자 했습니다.
   - 전에 정리했듯이 중요한것이 아래로, 롬복 같은녀석은 위로 보냈습니다.
- 프로필 생성시 이미지 저장 방식을 좀 간단하게 바꾸었습니다. 이미지들의 생성자체는 Profile 이 담당하도록 했습니다.
- DTO 작성시 전부 그냥 롬복 애너테이션 떡칠하는 식으로 편하게 통일하였습니다. 지금은 조 ㅁ일관성이 없었던거 같애용.