### PR TITLE
레디스 로직에 스크립트 적용

### DIFF
--- a/src/main/java/com/avalon/avalonchat/core/login/application/LoginServiceImpl.java
+++ b/src/main/java/com/avalon/avalonchat/core/login/application/LoginServiceImpl.java
@@ -73,7 +73,8 @@ public class LoginServiceImpl implements LoginService {
 	public EmailFindResponse findEmailByPhoneNumber(String phoneNumber) {
 		// 1. check authenticate phoneNumber
 		PhoneNumberKey phoneNumberKey = PhoneNumberKey.ofPurpose(PhoneNumberKeyPurpose.EMAIL_FIND, phoneNumber);
-		if (!phoneNumberAuthCodeStore.isAuthenticated(phoneNumberKey)) {
+		boolean authenticated = phoneNumberAuthCodeStore.isAuthenticated(phoneNumberKey);
+		if (!authenticated) {
 			throw new BadRequestException("phonenumber.no-auth", phoneNumber);
 		}
 
@@ -130,7 +131,7 @@ public class LoginServiceImpl implements LoginService {
 		smsMessageService.sendAuthenticationCode(phoneNumber, certificationCode);
 
 		// 3. put it to key-value store
-		phoneNumberAuthCodeStore.put(
+		phoneNumberAuthCodeStore.save(
 			PhoneNumberKey.ofPurpose(PhoneNumberKeyPurpose.EMAIL_FIND, phoneNumber),
 			AuthCodeValue.ofUnauthenticated(certificationCode)
 		);
@@ -145,7 +146,7 @@ public class LoginServiceImpl implements LoginService {
 		// 2. check authenticated
 		boolean authenticated = phoneNumberAuthCodeStore.checkKeyValueMatches(
 			PhoneNumberKey.ofPurpose(PhoneNumberKeyPurpose.EMAIL_FIND, phoneNumber),
-			request.getCertificationCode()
+			AuthCodeValue.ofUnauthenticated(request.getCertificationCode())
 		);
 
 		// 3. return

--- a/src/main/java/com/avalon/avalonchat/core/profile/application/ProfileServiceImpl.java
+++ b/src/main/java/com/avalon/avalonchat/core/profile/application/ProfileServiceImpl.java
@@ -47,7 +47,8 @@ public class ProfileServiceImpl implements ProfileService {
 
 		// 2. check
 		String phoneNumber = request.getPhoneNumber();
-		if (!phoneNumberKeyValueStore.isAuthenticated(PhoneNumberKey.fromString(phoneNumber))) {
+		boolean authenticated = !phoneNumberKeyValueStore.isAuthenticated(PhoneNumberKey.fromString(phoneNumber));
+		if (authenticated) {
 			throw new BadRequestException("phonenumber.no-auth", phoneNumber);
 		}
 

--- a/src/main/java/com/avalon/avalonchat/core/user/application/PhoneNumberAuthCodeStore.java
+++ b/src/main/java/com/avalon/avalonchat/core/user/application/PhoneNumberAuthCodeStore.java
@@ -2,22 +2,12 @@ package com.avalon.avalonchat.core.user.application;
 
 import com.avalon.avalonchat.core.user.application.keyvalue.AuthCodeValue;
 import com.avalon.avalonchat.core.user.application.keyvalue.PhoneNumberKey;
-import com.avalon.avalonchat.global.keyvalue.KeyValueStore;
 
-public interface PhoneNumberAuthCodeStore extends KeyValueStore<PhoneNumberKey, AuthCodeValue> {
+public interface PhoneNumberAuthCodeStore {
 
-	default boolean isAuthenticated(PhoneNumberKey key) {
-		AuthCodeValue authCodeValue = get(key);
-		return authCodeValue != null && authCodeValue.isAuthenticated();
-	}
+	void save(PhoneNumberKey key, AuthCodeValue value);
 
-	default boolean checkKeyValueMatches(PhoneNumberKey key, String authCodeValue) {
-		AuthCodeValue gotAuthCodeValue = get(key);
-		boolean checked = gotAuthCodeValue != null && gotAuthCodeValue.matches(authCodeValue);
-		if (checked) {
-			// do authenticate
-			put(key, AuthCodeValue.ofAuthenticated());
-		}
-		return checked;
-	}
+	boolean isAuthenticated(PhoneNumberKey key);
+
+	boolean checkKeyValueMatches(PhoneNumberKey key, AuthCodeValue value);
 }

--- a/src/main/java/com/avalon/avalonchat/core/user/application/UserServiceImpl.java
+++ b/src/main/java/com/avalon/avalonchat/core/user/application/UserServiceImpl.java
@@ -63,7 +63,7 @@ public class UserServiceImpl implements UserService {
 		smsMessageService.sendAuthenticationCode(phoneNumber, certificationCode);
 
 		// 3. put it to key-value store
-		phoneNumberKeyValueStore.put(
+		phoneNumberKeyValueStore.save(
 			PhoneNumberKey.fromString(phoneNumber),
 			AuthCodeValue.ofUnauthenticated(certificationCode)
 		);
@@ -79,7 +79,7 @@ public class UserServiceImpl implements UserService {
 		// 2. check authenticated
 		boolean authenticated = phoneNumberKeyValueStore.checkKeyValueMatches(
 			PhoneNumberKey.fromString(phoneNumber),
-			request.getCertificationCode()
+			AuthCodeValue.ofUnauthenticated(request.getCertificationCode())
 		);
 
 		// 3. return

--- a/src/main/java/com/avalon/avalonchat/global/keyvalue/KeyValueStore.java
+++ b/src/main/java/com/avalon/avalonchat/global/keyvalue/KeyValueStore.java
@@ -1,8 +1,0 @@
-package com.avalon.avalonchat.global.keyvalue;
-
-public interface KeyValueStore<K, V> {
-
-	void put(K key, V value);
-
-	V get(K key);
-}

--- a/src/main/java/com/avalon/avalonchat/infra/redis/RedisPhoneNumberAuthCodeStore.java
+++ b/src/main/java/com/avalon/avalonchat/infra/redis/RedisPhoneNumberAuthCodeStore.java
@@ -1,34 +1,50 @@
 package com.avalon.avalonchat.infra.redis;
 
+import java.util.List;
+
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.script.RedisScript;
 
 import com.avalon.avalonchat.core.user.application.PhoneNumberAuthCodeStore;
 import com.avalon.avalonchat.core.user.application.keyvalue.AuthCodeValue;
 import com.avalon.avalonchat.core.user.application.keyvalue.PhoneNumberKey;
 
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
 public class RedisPhoneNumberAuthCodeStore implements PhoneNumberAuthCodeStore {
 
-	private final ValueOperations<PhoneNumberKey, AuthCodeValue> phoneNumberAuthOperations;
+	private final RedisTemplate<PhoneNumberKey, AuthCodeValue> redisTemplate;
 
-	public RedisPhoneNumberAuthCodeStore(
-		RedisTemplate<PhoneNumberKey, AuthCodeValue> phoneNumberAuthRedisTemplate
-	) {
-		this.phoneNumberAuthOperations = phoneNumberAuthRedisTemplate.opsForValue();
-	}
+	private final RedisScript<Boolean> isAuthenticatedScript = RedisScript.of(
+		"local value = redis.call('GET', KEYS[1]) "
+			+ " return value ~= nil and value == 'AUTH_CODE::[AUTHENTICATED]' ",
+		Boolean.class
+	);
+
+	private final RedisScript<Boolean> checkKeyValueMatchesScript = RedisScript.of(
+		"local value = redis.call('GET', KEYS[1]) "
+			+ " if value == ARGV[1] "
+			+ " then "
+			+ "  redis.call('SET', KEYS[1], 'AUTH_CODE::[AUTHENTICATED]') "
+			+ "  return true "
+			+ " end "
+			+ " return false",
+		Boolean.class
+	);
 
 	@Override
 	public void save(PhoneNumberKey key, AuthCodeValue value) {
-
+		redisTemplate.opsForValue().set(key, value);
 	}
 
 	@Override
 	public boolean isAuthenticated(PhoneNumberKey key) {
-		return false;
+		return redisTemplate.execute(isAuthenticatedScript, List.of(key));
 	}
 
 	@Override
 	public boolean checkKeyValueMatches(PhoneNumberKey key, AuthCodeValue value) {
-		return false;
+		return redisTemplate.execute(checkKeyValueMatchesScript, List.of(key), value);
 	}
 }

--- a/src/main/java/com/avalon/avalonchat/infra/redis/RedisPhoneNumberAuthCodeStore.java
+++ b/src/main/java/com/avalon/avalonchat/infra/redis/RedisPhoneNumberAuthCodeStore.java
@@ -1,7 +1,5 @@
 package com.avalon.avalonchat.infra.redis;
 
-import java.time.Duration;
-
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 
@@ -20,12 +18,17 @@ public class RedisPhoneNumberAuthCodeStore implements PhoneNumberAuthCodeStore {
 	}
 
 	@Override
-	public void put(PhoneNumberKey key, AuthCodeValue value) {
-		phoneNumberAuthOperations.set(key, value, Duration.ofMinutes(30));
+	public void save(PhoneNumberKey key, AuthCodeValue value) {
+
 	}
 
 	@Override
-	public AuthCodeValue get(PhoneNumberKey key) {
-		return phoneNumberAuthOperations.get(key);
+	public boolean isAuthenticated(PhoneNumberKey key) {
+		return false;
+	}
+
+	@Override
+	public boolean checkKeyValueMatches(PhoneNumberKey key, AuthCodeValue value) {
+		return false;
 	}
 }

--- a/src/test/java/com/avalon/avalonchat/core/login/application/LoginServiceImplTest.java
+++ b/src/test/java/com/avalon/avalonchat/core/login/application/LoginServiceImplTest.java
@@ -91,8 +91,8 @@ public class LoginServiceImplTest {
 		PhoneNumberKey key = PhoneNumberKey.ofPurpose(PhoneNumberKeyPurpose.EMAIL_FIND, profile.getPhoneNumber());
 		AuthCodeValue authCodeValue = AuthCodeValue.fromString(authCode);
 
-		phoneNumberKeyValueStore.put(key, authCodeValue);
-		phoneNumberKeyValueStore.checkKeyValueMatches(key, authCode);
+		phoneNumberKeyValueStore.save(key, authCodeValue);
+		phoneNumberKeyValueStore.checkKeyValueMatches(key, authCodeValue);
 
 		//when
 		EmailFindResponse emailFindResponse = sut.findEmailByPhoneNumber(profile.getPhoneNumber());
@@ -114,7 +114,7 @@ public class LoginServiceImplTest {
 		PhoneNumberKey key = PhoneNumberKey.ofPurpose(PhoneNumberKeyPurpose.EMAIL_FIND, profile.getPhoneNumber());
 		AuthCodeValue authCodeValue = AuthCodeValue.fromString(authCode);
 
-		phoneNumberKeyValueStore.put(key, authCodeValue);
+		phoneNumberKeyValueStore.save(key, authCodeValue);
 
 		//when & then
 		assertThatExceptionOfType(RuntimeException.class)

--- a/src/test/java/com/avalon/avalonchat/core/profile/application/ProfileServiceImplTest.java
+++ b/src/test/java/com/avalon/avalonchat/core/profile/application/ProfileServiceImplTest.java
@@ -74,7 +74,7 @@ class ProfileServiceImplTest {
 		String toPhoneNumber = "01055110625";
 
 		smsMessageService.sendAuthenticationCode(toPhoneNumber, certificationCode);
-		phoneNumberAuthKeyValueStore.put(
+		phoneNumberAuthKeyValueStore.save(
 			PhoneNumberKey.fromString(toPhoneNumber),
 			AuthCodeValue.ofUnauthenticated(certificationCode)
 		);
@@ -114,7 +114,7 @@ class ProfileServiceImplTest {
 		String toPhoneNumber = "01055110625";
 
 		smsMessageService.sendAuthenticationCode(toPhoneNumber, certificationCode);
-		phoneNumberAuthKeyValueStore.put(
+		phoneNumberAuthKeyValueStore.save(
 			PhoneNumberKey.fromString(toPhoneNumber),
 			AuthCodeValue.ofUnauthenticated(certificationCode)
 		);

--- a/src/test/java/com/avalon/avalonchat/core/user/application/UserServiceImplTest.java
+++ b/src/test/java/com/avalon/avalonchat/core/user/application/UserServiceImplTest.java
@@ -69,10 +69,10 @@ class UserServiceImplTest {
 
 		// when
 		sut.sendPhoneNumberAuthentication(request);
-		AuthCodeValue authCodeValue = phoneNumberAuthKeyValueStore.get(PhoneNumberKey.fromString(toPhoneNumber));
+		boolean authenticated = phoneNumberAuthKeyValueStore.isAuthenticated(PhoneNumberKey.fromString(toPhoneNumber));
 
 		// then
-		assertThat(authCodeValue.isAuthenticated()).isFalse();
+		assertThat(authenticated).isFalse();
 	}
 
 	@Test
@@ -83,7 +83,7 @@ class UserServiceImplTest {
 		String toPhoneNumber = "01055110625";
 
 		smsMessageService.sendAuthenticationCode(toPhoneNumber, certificationCode);
-		phoneNumberAuthKeyValueStore.put(
+		phoneNumberAuthKeyValueStore.save(
 			PhoneNumberKey.fromString(toPhoneNumber),
 			AuthCodeValue.ofUnauthenticated(certificationCode)
 		);

--- a/src/test/java/com/avalon/avalonchat/infra/redis/RedisPhoneNumberAuthCodeStoreTest.java
+++ b/src/test/java/com/avalon/avalonchat/infra/redis/RedisPhoneNumberAuthCodeStoreTest.java
@@ -18,18 +18,48 @@ class RedisPhoneNumberAuthCodeStoreTest {
 	private RedisPhoneNumberAuthCodeStore sut;
 
 	@Test
-	void get_set() {
+	void isAuthenticated() {
 		// given
-		PhoneNumberKey key = PhoneNumberKey.fromString("01012345678");
-		AuthCodeValue value = AuthCodeValue.ofUnauthenticated("cert-code");
+		PhoneNumberKey key1 = PhoneNumberKey.fromString("01011111111");
+		PhoneNumberKey key2 = PhoneNumberKey.fromString("01022222222");
+		PhoneNumberKey key3 = PhoneNumberKey.fromString("01033333333");
 
 		// when
-		sut.save(key, value);
-		boolean authenticated1 = sut.isAuthenticated(key);
-		boolean authenticated2 = sut.isAuthenticated(PhoneNumberKey.fromString("01099999999"));
+		sut.save(key1, AuthCodeValue.ofUnauthenticated("cert-code"));
+		sut.save(key2, AuthCodeValue.ofAuthenticated());
+
+		boolean authenticated1 = sut.isAuthenticated(key1);
+		boolean authenticated2 = sut.isAuthenticated(key2);
+		boolean authenticated3 = sut.isAuthenticated(key3);
 
 		// then
-		assertThat(authenticated1).isTrue();
-		assertThat(authenticated2).isFalse();
+		assertThat(authenticated1).isFalse();
+		assertThat(authenticated2).isTrue();
+		assertThat(authenticated3).isFalse();
+	}
+
+	@Test
+	void checkKeyValueMatches() {
+		// given
+		PhoneNumberKey key1 = PhoneNumberKey.fromString("01011111111");
+		PhoneNumberKey key2 = PhoneNumberKey.fromString("01022222222");
+		PhoneNumberKey key3 = PhoneNumberKey.fromString("01033333333");
+
+		// when
+		sut.save(key1, AuthCodeValue.ofUnauthenticated("123456"));
+		sut.save(key2, AuthCodeValue.ofAuthenticated());
+
+		boolean match1 = sut.checkKeyValueMatches(key1, AuthCodeValue.ofUnauthenticated("123456"));
+		boolean match2 = sut.checkKeyValueMatches(key2, AuthCodeValue.ofUnauthenticated("123456"));
+		boolean match3 = sut.checkKeyValueMatches(key3, AuthCodeValue.ofUnauthenticated("123456"));
+
+		// then
+		assertThat(match1).isTrue();
+		assertThat(match2).isFalse();
+		assertThat(match3).isFalse();
+
+		assertThat(sut.isAuthenticated(key1)).isTrue(); // key1 updated to authenticated
+		assertThat(sut.isAuthenticated(key2)).isTrue();
+		assertThat(sut.isAuthenticated(key3)).isFalse();
 	}
 }

--- a/src/test/java/com/avalon/avalonchat/infra/redis/RedisPhoneNumberAuthCodeStoreTest.java
+++ b/src/test/java/com/avalon/avalonchat/infra/redis/RedisPhoneNumberAuthCodeStoreTest.java
@@ -24,13 +24,12 @@ class RedisPhoneNumberAuthCodeStoreTest {
 		AuthCodeValue value = AuthCodeValue.ofUnauthenticated("cert-code");
 
 		// when
-		sut.put(key, value);
-		AuthCodeValue authCodeValue = sut.get(key);
-		AuthCodeValue nullCodeValue = sut.get(PhoneNumberKey.fromString("01099999999"));
+		sut.save(key, value);
+		boolean authenticated1 = sut.isAuthenticated(key);
+		boolean authenticated2 = sut.isAuthenticated(PhoneNumberKey.fromString("01099999999"));
 
 		// then
-		assertThat(authCodeValue.isAuthenticated()).isFalse();
-		assertThat(authCodeValue.matches("cert-code")).isTrue();
-		assertThat(nullCodeValue).isNull();
+		assertThat(authenticated1).isTrue();
+		assertThat(authenticated2).isFalse();
 	}
 }

--- a/src/test/java/com/avalon/avalonchat/study/RedisLuaScriptStudyTest.java
+++ b/src/test/java/com/avalon/avalonchat/study/RedisLuaScriptStudyTest.java
@@ -1,0 +1,113 @@
+package com.avalon.avalonchat.study;
+
+import static java.util.List.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Disabled
+public class RedisLuaScriptStudyTest {
+
+	RedisTemplate<String, String> redisTemplate;
+	ValueOperations<String, String> valueOp;
+
+	@BeforeEach
+	void setUp() {
+		// setup
+		redisTemplate = new RedisTemplate<>();
+		RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration("127.0.0.1", 6379);
+		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(configuration);
+		connectionFactory.afterPropertiesSet();
+
+		redisTemplate.setConnectionFactory(connectionFactory);
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		redisTemplate.setValueSerializer(new StringRedisSerializer());
+		redisTemplate.afterPropertiesSet();
+
+		valueOp = redisTemplate.opsForValue();
+	}
+
+	@Test
+	void basic_script_1() {
+		RedisScript<Boolean> script = RedisScript.of(
+			"return true",
+			Boolean.class
+		);
+
+		Boolean result = redisTemplate.execute(script, Collections.emptyList());
+
+		assertThat(result).isTrue();
+	}
+
+	@Test
+	void basic_script_2() {
+		RedisScript<Boolean> script = RedisScript.of(
+			"return tonumber(ARGV[1]) > 50",
+			Boolean.class
+		);
+
+		assertThat(redisTemplate.execute(script, Collections.emptyList(), "50")).isFalse();
+		assertThat(redisTemplate.execute(script, Collections.emptyList(), "51")).isTrue();
+	}
+
+	// 주어진 key 에 대한 인증 여부를 응답하는 script
+	@Test
+	void script_1() {
+		String luaScript = "local value = redis.call('GET', KEYS[1]) "
+			+ " return value ~= nil and value == 'AUTHCODE::[AUTHENTICATED]' ";
+
+		RedisScript<Boolean> redisScript = RedisScript.of(
+			luaScript,
+			Boolean.class
+		);
+		valueOp.set("PHONENUMBER::01012345678", "AUTHCODE::123456");
+		valueOp.set("PHONENUMBER::01011112222", "AUTHCODE::[AUTHENTICATED]");
+
+		assertThat(redisTemplate.execute(redisScript, of("PHONENUMBER::01012345678"))).isFalse();
+		assertThat(redisTemplate.execute(redisScript, of("PHONENUMBER::01011112222"))).isTrue();
+		assertThat(redisTemplate.execute(redisScript, of("PHONENUMBER::11112222333"))).isFalse();
+	}
+
+	// 주어진 key, value 에 대해 매칭 여부를 판단.
+	// 매치하는 경우 AUTHENTICATED 로 업데이트.
+	// 매치 여부를 응답하는 script
+	@Test
+	void script_2() {
+		String luaScript = "local value = redis.call('GET', KEYS[1]) "
+			+ " if value == ARGV[1] "
+			+ " then "
+			+ "  redis.call('SET', KEYS[1], 'AUTHCODE::[AUTHENTICATED]') "
+			+ "  return true "
+			+ " end "
+			+ " return false";
+
+		RedisScript<Boolean> redisScript = RedisScript.of(
+			luaScript,
+			Boolean.class
+		);
+		valueOp.set("PHONENUMBER::01012345678", "AUTHCODE::123456");
+		valueOp.set("PHONENUMBER::01011112222", "AUTHCODE::[AUTHENTICATED]");
+
+		assertThat(redisTemplate.execute(redisScript, of("PHONENUMBER::01012345678"), "AUTHCODE::123456")).isTrue();
+		assertThat(redisTemplate.execute(redisScript, of("PHONENUMBER::01011112222"), "AUTHCODE::123456")).isFalse();
+		assertThat(redisTemplate.execute(redisScript, of("PHONENUMBER::11112222333"), "AUTHCODE::123456")).isFalse();
+
+		String value1 = valueOp.get("PHONENUMBER::01012345678");
+		String value2 = valueOp.get("PHONENUMBER::01011112222");
+		String value3 = valueOp.get("PHONENUMBER::11112222333");
+
+		assertThat(value1).isEqualTo("AUTHCODE::[AUTHENTICATED]");
+		assertThat(value2).isEqualTo("AUTHCODE::[AUTHENTICATED]");
+		assertThat(value3).isNull();
+	}
+}


### PR DESCRIPTION
## Summary
최근 레디스를 공부해보니 저희 프로젝트에도 적용하면 좋을거 같은 방법이 있어 찾아서 적용해보았습니다.

1. 인증 코드 저장 - 주어진 key, value 에 대해 저장한다.  (redis.set())
2. 인증 여부 확인 로직 - redis.get() 을 호출한다 -> value 가 존재하고 `[Authenticated]` 인 경우는 인증된 것이다.
3. 인증 처리 로직 - redis.get() 을 호출한다 -> 주어진 코드와 비교한다 -> 일치한다면 `[Authenticated]` 로 업데이트 (`redis.set()`) 하고 그렇지 않다면 인증 실패이다.

인증 코드와 관련된 주요 로직인데 1 을 제외하고는 후처리가 필요하거나 여러번의 redis 호출이 필요합니다.
공부해보니 lua-script 라는것으로 이런 로직을 한 덩어리로 처리 할 수 있어서 적용해 보았습니다.

RDB 에서의 stored-procedure 와 유사한 역할 이라고 합니다.

stored-procedure 와 비슷하게 유지보수나 로직의 분산 측면에서 단점도 있지만
성능적인 이점도 있고... 배운김에 한번 써보고 싶어서 적용해 보았습니다.