### PR TITLE
Feature/#115

### DIFF
--- a/src/main/java/com/avalon/avalonchat/DataInitializer.java
+++ b/src/main/java/com/avalon/avalonchat/DataInitializer.java
@@ -45,8 +45,8 @@ public class DataInitializer implements ApplicationRunner {
 		Profile profile2 = profileRepository.save(new Profile(user2, "bio2", now(), "user2", "010-2222-2222"));
 		Profile profile3 = profileRepository.save(new Profile(user3, "bio3", now(), "user3", "010-3333-3333"));
 
-		Friend friend12 = friendRepository.save(new Friend(profile1, profile2));
-		Friend friend21 = friendRepository.save(new Friend(profile2, profile1));
-		Friend friend23 = friendRepository.save(new Friend(profile2, profile3));
+		Friend friend12 = friendRepository.save(new Friend(profile1, profile2, "user2"));
+		Friend friend21 = friendRepository.save(new Friend(profile2, profile1, "user1"));
+		Friend friend23 = friendRepository.save(new Friend(profile2, profile3, "user3"));
 	}
 }

--- a/src/main/java/com/avalon/avalonchat/controller/FriendController.java
+++ b/src/main/java/com/avalon/avalonchat/controller/FriendController.java
@@ -15,12 +15,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.avalon.avalonchat.core.friend.application.FriendService;
-import com.avalon.avalonchat.core.friend.dto.FriendAddRequest;
-import com.avalon.avalonchat.core.friend.dto.FriendAddResponse;
 import com.avalon.avalonchat.core.friend.dto.FriendPhoneNumberAddRequest;
 import com.avalon.avalonchat.core.friend.dto.FriendPhoneNumberAddResponse;
 import com.avalon.avalonchat.core.friend.dto.FriendStatusUpdateRequest;
 import com.avalon.avalonchat.core.friend.dto.FriendStatusUpdateResponse;
+import com.avalon.avalonchat.core.friend.dto.FriendSynchronizeRequest;
+import com.avalon.avalonchat.core.friend.dto.FriendSynchronizeResponse;
 import com.avalon.avalonchat.global.model.SecurityUser;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -37,6 +37,11 @@ import lombok.extern.slf4j.Slf4j;
 public class FriendController {
 	private final FriendService friendService;
 
+	@Operation(
+		summary = "연락처 친구 추가",
+		description = "phoneNumber 를 이용하여 friend 레코드를 추가합니다.",
+		security = {@SecurityRequirement(name = "bearer-key")}
+	)
 	@PostMapping("/phoneNumber")
 	public ResponseEntity<FriendPhoneNumberAddResponse> addFriendByPhoneNumber(
 		@AuthenticationPrincipal SecurityUser securityUser,
@@ -47,17 +52,18 @@ public class FriendController {
 	}
 
 	@Operation(
-		summary = "[WIP] 친구 추가",
+		summary = "친구 동기화",
 		description = "phoneNumbers 를 이용하여 friend 레코드를 추가합니다.",
 		security = {@SecurityRequirement(name = "bearer-key")}
 	)
 	@PostMapping
-	public ResponseEntity<Map<String, List<FriendAddResponse>>> addFriend(
+	public ResponseEntity<Map<String, List<FriendSynchronizeResponse>>> synchronizeFriend(
 		@AuthenticationPrincipal SecurityUser securityUser,
-		FriendAddRequest request
+		FriendSynchronizeRequest request
 	) {
-		List<FriendAddResponse> responses = friendService.addFriend(securityUser.getProfileId(), request);
-		Map<String, List<FriendAddResponse>> body = Map.of("data", responses);
+		List<FriendSynchronizeResponse> responses
+			= friendService.synchronizeFriend(securityUser.getProfileId(), request);
+		Map<String, List<FriendSynchronizeResponse>> body = Map.of("data", responses);
 		return created(body);
 	}
 

--- a/src/main/java/com/avalon/avalonchat/controller/FriendController.java
+++ b/src/main/java/com/avalon/avalonchat/controller/FriendController.java
@@ -17,6 +17,8 @@ import org.springframework.web.bind.annotation.RestController;
 import com.avalon.avalonchat.core.friend.application.FriendService;
 import com.avalon.avalonchat.core.friend.dto.FriendAddRequest;
 import com.avalon.avalonchat.core.friend.dto.FriendAddResponse;
+import com.avalon.avalonchat.core.friend.dto.FriendPhoneNumberAddRequest;
+import com.avalon.avalonchat.core.friend.dto.FriendPhoneNumberAddResponse;
 import com.avalon.avalonchat.core.friend.dto.FriendStatusUpdateRequest;
 import com.avalon.avalonchat.core.friend.dto.FriendStatusUpdateResponse;
 import com.avalon.avalonchat.global.model.SecurityUser;
@@ -34,6 +36,15 @@ import lombok.extern.slf4j.Slf4j;
 @RestController
 public class FriendController {
 	private final FriendService friendService;
+
+	@PostMapping("/phoneNumber")
+	public ResponseEntity<FriendPhoneNumberAddResponse> addFriendByPhoneNumber(
+		@AuthenticationPrincipal SecurityUser securityUser,
+		FriendPhoneNumberAddRequest request
+	) {
+		FriendPhoneNumberAddResponse body = friendService.addFriendByPhoneNumber(securityUser.getProfileId(), request);
+		return created(body);
+	}
 
 	@Operation(
 		summary = "[WIP] 친구 추가",

--- a/src/main/java/com/avalon/avalonchat/core/friend/application/FriendService.java
+++ b/src/main/java/com/avalon/avalonchat/core/friend/application/FriendService.java
@@ -4,10 +4,14 @@ import java.util.List;
 
 import com.avalon.avalonchat.core.friend.dto.FriendAddRequest;
 import com.avalon.avalonchat.core.friend.dto.FriendAddResponse;
+import com.avalon.avalonchat.core.friend.dto.FriendPhoneNumberAddRequest;
+import com.avalon.avalonchat.core.friend.dto.FriendPhoneNumberAddResponse;
 import com.avalon.avalonchat.core.friend.dto.FriendStatusUpdateRequest;
 import com.avalon.avalonchat.core.friend.dto.FriendStatusUpdateResponse;
 
 public interface FriendService {
+
+	FriendPhoneNumberAddResponse addFriendByPhoneNumber(long profileId, FriendPhoneNumberAddRequest request);
 
 	/**
 	 * add friends by given request(phonenumber list)

--- a/src/main/java/com/avalon/avalonchat/core/friend/application/FriendService.java
+++ b/src/main/java/com/avalon/avalonchat/core/friend/application/FriendService.java
@@ -2,12 +2,12 @@ package com.avalon.avalonchat.core.friend.application;
 
 import java.util.List;
 
-import com.avalon.avalonchat.core.friend.dto.FriendAddRequest;
-import com.avalon.avalonchat.core.friend.dto.FriendAddResponse;
 import com.avalon.avalonchat.core.friend.dto.FriendPhoneNumberAddRequest;
 import com.avalon.avalonchat.core.friend.dto.FriendPhoneNumberAddResponse;
 import com.avalon.avalonchat.core.friend.dto.FriendStatusUpdateRequest;
 import com.avalon.avalonchat.core.friend.dto.FriendStatusUpdateResponse;
+import com.avalon.avalonchat.core.friend.dto.FriendSynchronizeRequest;
+import com.avalon.avalonchat.core.friend.dto.FriendSynchronizeResponse;
 
 public interface FriendService {
 
@@ -20,7 +20,7 @@ public interface FriendService {
 	 * @param request   - phonenumber list
 	 * @return - added Friend profiles
 	 */
-	List<FriendAddResponse> addFriend(long profileId, FriendAddRequest request);
+	List<FriendSynchronizeResponse> synchronizeFriend(long profileId, FriendSynchronizeRequest request);
 
 	FriendStatusUpdateResponse updateFriendStatus(
 		long myProfileId,

--- a/src/main/java/com/avalon/avalonchat/core/friend/application/FriendServiceImpl.java
+++ b/src/main/java/com/avalon/avalonchat/core/friend/application/FriendServiceImpl.java
@@ -1,5 +1,6 @@
 package com.avalon.avalonchat.core.friend.application;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -8,12 +9,12 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.avalon.avalonchat.core.friend.domain.Friend;
 import com.avalon.avalonchat.core.friend.domain.FriendRepository;
-import com.avalon.avalonchat.core.friend.dto.FriendAddRequest;
-import com.avalon.avalonchat.core.friend.dto.FriendAddResponse;
 import com.avalon.avalonchat.core.friend.dto.FriendPhoneNumberAddRequest;
 import com.avalon.avalonchat.core.friend.dto.FriendPhoneNumberAddResponse;
 import com.avalon.avalonchat.core.friend.dto.FriendStatusUpdateRequest;
 import com.avalon.avalonchat.core.friend.dto.FriendStatusUpdateResponse;
+import com.avalon.avalonchat.core.friend.dto.FriendSynchronizeRequest;
+import com.avalon.avalonchat.core.friend.dto.FriendSynchronizeResponse;
 import com.avalon.avalonchat.core.profile.domain.Profile;
 import com.avalon.avalonchat.core.profile.domain.ProfileRepository;
 import com.avalon.avalonchat.global.error.exception.BadRequestException;
@@ -55,25 +56,40 @@ public class FriendServiceImpl implements FriendService {
 
 	@Override
 	@Transactional
-	public List<FriendAddResponse> addFriend(long profileId, FriendAddRequest request) {
-		// 1. find profile & create friends
+	public List<FriendSynchronizeResponse> synchronizeFriend(long profileId, FriendSynchronizeRequest request) {
+		// 1. find myProfile
 		Profile myProfile = profileRepository.findById(profileId)
 			.orElseThrow(() -> new NotFoundException("profile", profileId));
 
+		// 2. get phoneNumbers from request
+		List<String> phoneNumbers = new ArrayList<>(request.getFriendsInfo().keySet());
+
+		// 3. filter if already exists
 		List<String> friendPhoneNumbers = profileRepository.findAllFriendPhoneNumbersByMyProfileId(myProfile.getId());
 
-		List<Friend> friends = profileRepository.findAllByPhoneNumberIn(request.getPhoneNumbers()).stream()
+		List<Profile> friendProfiles = profileRepository.findAllByPhoneNumberIn(phoneNumbers).stream()
 			.filter(profile -> !friendPhoneNumbers.contains(profile.getPhoneNumber()))
-			.map(profile -> new Friend(myProfile, profile))
 			.collect(Collectors.toList());
 
-		// 2. save them
-		List<Long> friendIds = friendRepository.saveAll(friends).stream()
-			.map(Friend::getId)
-			.collect(Collectors.toList());
+		// 4. create friends & responses
+		List<Friend> friends = new ArrayList<>();
+		List<FriendSynchronizeResponse> responses = new ArrayList<>();
 
-		// 3. return
-		return friendRepository.findAllByFriendIds(friendIds);
+		for (Profile friendProfile : friendProfiles) {
+			Friend friend = new Friend(
+				myProfile,
+				friendProfile,
+				request.getFriendsInfo().get(friendProfile.getPhoneNumber())
+			);
+			friends.add(friend);
+			responses.add(FriendSynchronizeResponse.of(friendProfile, friend));
+		}
+
+		// 5. save them
+		friendRepository.saveAll(friends);
+
+		// 6. return responses
+		return responses;
 	}
 
 	@Override

--- a/src/main/java/com/avalon/avalonchat/core/friend/application/FriendServiceImpl.java
+++ b/src/main/java/com/avalon/avalonchat/core/friend/application/FriendServiceImpl.java
@@ -37,17 +37,19 @@ public class FriendServiceImpl implements FriendService {
 		Profile myProfile = profileRepository.findById(profileId)
 			.orElseThrow(() -> new NotFoundException("myProfile", profileId));
 
-		Profile friendProfile = profileRepository.findByPhoneNumber(request.getPhoneNumber())
+		Profile friendProfile = profileRepository.findByPhoneNumberAndNickname(request.getPhoneNumber(),
+				request.getFriendProfileNickname())
 			.orElseThrow(() -> new NotFoundException("friendProfile", request.getPhoneNumber()));
 
 		// 2. check if already exists
-		boolean exists = friendRepository.existsByFriendProfileId(friendProfile.getId());
+		boolean exists
+			= friendRepository.existsByFriendProfileIdAndMyProfileId(friendProfile.getId(), myProfile.getId());
 		if (exists) {
 			throw new BadRequestException("addFriendByPhoneNumber-failed.already-exists");
 		}
 
 		// 3. create friend & save them
-		Friend friend = new Friend(myProfile, friendProfile, request.getDisplayName());
+		Friend friend = new Friend(myProfile, friendProfile, request.getFriendProfileNickname());
 		Friend savedFriend = friendRepository.save(friend);
 
 		// 4. create & return response

--- a/src/main/java/com/avalon/avalonchat/core/friend/domain/Friend.java
+++ b/src/main/java/com/avalon/avalonchat/core/friend/domain/Friend.java
@@ -50,7 +50,6 @@ public class Friend extends BaseAuditingEntity {
 		this.displayName = displayName;
 	}
 
-	//TODO 아래의 생성자 친구 동기화 API 수정 후 삭제
 	public Friend(Profile myProfile, Profile friendProfile) {
 		checkNotNull(myProfile, "Friend.myProfile cannot be null");
 		checkNotNull(myProfile, "Friend.friendProfile cannot be null");
@@ -58,6 +57,7 @@ public class Friend extends BaseAuditingEntity {
 		this.myProfile = myProfile;
 		this.friendProfile = friendProfile;
 		this.status = Status.NORMAL;
+		this.displayName = friendProfile.getNickname();
 	}
 
 	public void updateStatus(Status status) {

--- a/src/main/java/com/avalon/avalonchat/core/friend/domain/Friend.java
+++ b/src/main/java/com/avalon/avalonchat/core/friend/domain/Friend.java
@@ -37,6 +37,20 @@ public class Friend extends BaseAuditingEntity {
 	@Enumerated(STRING)
 	private Status status;
 
+	private String displayName;
+
+	public Friend(Profile myProfile, Profile friendProfile, String displayName) {
+		checkNotNull(myProfile, "Friend.myProfile cannot be null");
+		checkNotNull(myProfile, "Friend.friendProfile cannot be null");
+		checkNotNull(displayName, "friend.displayName cannot be null");
+
+		this.myProfile = myProfile;
+		this.friendProfile = friendProfile;
+		this.status = Status.NORMAL;
+		this.displayName = displayName;
+	}
+
+	//TODO 아래의 생성자 친구 동기화 API 수정 후 삭제
 	public Friend(Profile myProfile, Profile friendProfile) {
 		checkNotNull(myProfile, "Friend.myProfile cannot be null");
 		checkNotNull(myProfile, "Friend.friendProfile cannot be null");

--- a/src/main/java/com/avalon/avalonchat/core/friend/domain/Friend.java
+++ b/src/main/java/com/avalon/avalonchat/core/friend/domain/Friend.java
@@ -37,27 +37,17 @@ public class Friend extends BaseAuditingEntity {
 	@Enumerated(STRING)
 	private Status status;
 
-	private String displayName;
+	private String friendName;
 
-	public Friend(Profile myProfile, Profile friendProfile, String displayName) {
+	public Friend(Profile myProfile, Profile friendProfile, String friendName) {
 		checkNotNull(myProfile, "Friend.myProfile cannot be null");
 		checkNotNull(myProfile, "Friend.friendProfile cannot be null");
-		checkNotNull(displayName, "friend.displayName cannot be null");
+		checkNotNull(friendName, "friend.displayName cannot be null");
 
 		this.myProfile = myProfile;
 		this.friendProfile = friendProfile;
 		this.status = Status.NORMAL;
-		this.displayName = displayName;
-	}
-
-	public Friend(Profile myProfile, Profile friendProfile) {
-		checkNotNull(myProfile, "Friend.myProfile cannot be null");
-		checkNotNull(myProfile, "Friend.friendProfile cannot be null");
-
-		this.myProfile = myProfile;
-		this.friendProfile = friendProfile;
-		this.status = Status.NORMAL;
-		this.displayName = friendProfile.getNickname();
+		this.friendName = friendName;
 	}
 
 	public void updateStatus(Status status) {

--- a/src/main/java/com/avalon/avalonchat/core/friend/domain/FriendRepository.java
+++ b/src/main/java/com/avalon/avalonchat/core/friend/domain/FriendRepository.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FriendRepository extends JpaRepository<Friend, Long> {
-	boolean existsByFriendProfileId(long friendId);
+	boolean existsByFriendProfileIdAndMyProfileId(long friendProfileId, long myProfileId);
 
 	Optional<Friend> findByMyProfileIdAndFriendProfileId(long myProfileId, long friendProfileId);
 }

--- a/src/main/java/com/avalon/avalonchat/core/friend/domain/FriendRepository.java
+++ b/src/main/java/com/avalon/avalonchat/core/friend/domain/FriendRepository.java
@@ -10,6 +10,8 @@ import org.springframework.data.repository.query.Param;
 import com.avalon.avalonchat.core.friend.dto.FriendAddResponse;
 
 public interface FriendRepository extends JpaRepository<Friend, Long> {
+	boolean existsByFriendProfileId(long friendId);
+
 	Optional<Friend> findByMyProfileIdAndFriendProfileId(long myProfileId, long friendProfileId);
 
 	@Query("SELECT new com.avalon.avalonchat.core.friend.dto.FriendAddResponse("

--- a/src/main/java/com/avalon/avalonchat/core/friend/domain/FriendRepository.java
+++ b/src/main/java/com/avalon/avalonchat/core/friend/domain/FriendRepository.java
@@ -1,27 +1,11 @@
 package com.avalon.avalonchat.core.friend.domain;
 
-import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-
-import com.avalon.avalonchat.core.friend.dto.FriendAddResponse;
 
 public interface FriendRepository extends JpaRepository<Friend, Long> {
 	boolean existsByFriendProfileId(long friendId);
 
 	Optional<Friend> findByMyProfileIdAndFriendProfileId(long myProfileId, long friendProfileId);
-
-	@Query("SELECT new com.avalon.avalonchat.core.friend.dto.FriendAddResponse("
-		+ "fp.id, "
-		+ "fp.nickname, "
-		+ "fp.bio, "
-		+ "fp.latestProfileImageUrl, "
-		+ "f.status) "
-		+ "FROM Friend f "
-		+ "INNER JOIN f.friendProfile fp "
-		+ "WHERE f.id IN :friendIds")
-	List<FriendAddResponse> findAllByFriendIds(@Param("friendIds") List<Long> friendIds);
 }

--- a/src/main/java/com/avalon/avalonchat/core/friend/dto/FriendPhoneNumberAddRequest.java
+++ b/src/main/java/com/avalon/avalonchat/core/friend/dto/FriendPhoneNumberAddRequest.java
@@ -1,0 +1,16 @@
+package com.avalon.avalonchat.core.friend.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class FriendPhoneNumberAddRequest {
+	@Schema(description = "핸드폰 번호", example = "010-1234-5678")
+	private String phoneNumber;
+	@Schema(description = "친구 이름", example = "홍길동99")
+	private String displayName;
+}

--- a/src/main/java/com/avalon/avalonchat/core/friend/dto/FriendPhoneNumberAddRequest.java
+++ b/src/main/java/com/avalon/avalonchat/core/friend/dto/FriendPhoneNumberAddRequest.java
@@ -11,6 +11,6 @@ import lombok.NoArgsConstructor;
 public class FriendPhoneNumberAddRequest {
 	@Schema(description = "핸드폰 번호", example = "010-1234-5678")
 	private String phoneNumber;
-	@Schema(description = "친구 이름", example = "홍길동99")
-	private String displayName;
+	@Schema(description = "친구 프로필 닉네임", example = "홍길동")
+	private String friendProfileNickname;
 }

--- a/src/main/java/com/avalon/avalonchat/core/friend/dto/FriendPhoneNumberAddResponse.java
+++ b/src/main/java/com/avalon/avalonchat/core/friend/dto/FriendPhoneNumberAddResponse.java
@@ -15,7 +15,7 @@ public class FriendPhoneNumberAddResponse {
 	@Schema(description = "친구 프로필 ID", example = "1")
 	private long friendProfileId;
 	@Schema(description = "친구 프로필 이름", example = "홍길동99")
-	private String displayName;
+	private String friendName;
 	@Schema(description = "친구 프로필 상태메시지", example = "hi there")
 	private String bio;
 	@Schema(description = "친구 프로필 이미지 주소", example = "http://profile/image/url")
@@ -26,7 +26,7 @@ public class FriendPhoneNumberAddResponse {
 	public static FriendPhoneNumberAddResponse of(Profile profile, Friend friend) {
 		return new FriendPhoneNumberAddResponse(
 			profile.getId(),
-			friend.getDisplayName(),
+			friend.getFriendName(),
 			profile.getBio(),
 			profile.getLatestProfileImageUrl(),
 			friend.getStatus()

--- a/src/main/java/com/avalon/avalonchat/core/friend/dto/FriendPhoneNumberAddResponse.java
+++ b/src/main/java/com/avalon/avalonchat/core/friend/dto/FriendPhoneNumberAddResponse.java
@@ -1,0 +1,35 @@
+package com.avalon.avalonchat.core.friend.dto;
+
+import com.avalon.avalonchat.core.friend.domain.Friend;
+import com.avalon.avalonchat.core.profile.domain.Profile;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class FriendPhoneNumberAddResponse {
+	@Schema(description = "친구 프로필 ID", example = "1")
+	private long friendProfileId;
+	@Schema(description = "친구 프로필 이름", example = "홍길동99")
+	private String displayName;
+	@Schema(description = "친구 프로필 상태메시지", example = "hi there")
+	private String bio;
+	@Schema(description = "친구 프로필 이미지 주소", example = "http://profile/image/url")
+	private String profileImage;
+	@Schema(description = "친구 상태", example = "NORMAL")
+	private Friend.Status status;
+
+	public static FriendPhoneNumberAddResponse of(Profile profile, Friend friend) {
+		return new FriendPhoneNumberAddResponse(
+			profile.getId(),
+			friend.getDisplayName(),
+			profile.getBio(),
+			profile.getLatestProfileImageUrl(),
+			friend.getStatus()
+		);
+	}
+}

--- a/src/main/java/com/avalon/avalonchat/core/friend/dto/FriendSynchronizeRequest.java
+++ b/src/main/java/com/avalon/avalonchat/core/friend/dto/FriendSynchronizeRequest.java
@@ -1,6 +1,6 @@
 package com.avalon.avalonchat.core.friend.dto;
 
-import java.util.List;
+import java.util.Map;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Data
-public class FriendAddRequest {
-	@Schema(description = "핸드폰 번호 리스트", example = "[010-1234-5678, 010-1212-3434]")
-	private List<String> phoneNumbers;
+public class FriendSynchronizeRequest {
+	@Schema(description = "추가할 친구의 핸드폰 번호, 이름 정보 맵", example = "{010-1234-5678 : 홍길동99, ...}")
+	private Map<String, String> friendsInfo;
 }

--- a/src/main/java/com/avalon/avalonchat/core/friend/dto/FriendSynchronizeResponse.java
+++ b/src/main/java/com/avalon/avalonchat/core/friend/dto/FriendSynchronizeResponse.java
@@ -1,6 +1,7 @@
 package com.avalon.avalonchat.core.friend.dto;
 
 import com.avalon.avalonchat.core.friend.domain.Friend;
+import com.avalon.avalonchat.core.profile.domain.Profile;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
@@ -10,15 +11,25 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Data
-public class FriendAddResponse {
+public class FriendSynchronizeResponse {
 	@Schema(description = "친구 프로필 ID", example = "1")
 	private long friendProfileId;
-	@Schema(description = "친구 프로필 닉네임", example = "nickName")
-	private String nickname;
+	@Schema(description = "친구 프로필 이름", example = "홍길동99")
+	private String displayName;
 	@Schema(description = "친구 프로필 상태메시지", example = "hi there")
 	private String bio;
 	@Schema(description = "친구 프로필 이미지 주소", example = "http://profile/image/url")
 	private String profileImage;
 	@Schema(description = "친구 상태", example = "NORMAL")
 	private Friend.Status status;
+
+	public static FriendSynchronizeResponse of(Profile profile, Friend friend) {
+		return new FriendSynchronizeResponse(
+			profile.getId(),
+			friend.getDisplayName(),
+			profile.getBio(),
+			profile.getLatestProfileImageUrl(),
+			friend.getStatus()
+		);
+	}
 }

--- a/src/main/java/com/avalon/avalonchat/core/friend/dto/FriendSynchronizeResponse.java
+++ b/src/main/java/com/avalon/avalonchat/core/friend/dto/FriendSynchronizeResponse.java
@@ -15,7 +15,7 @@ public class FriendSynchronizeResponse {
 	@Schema(description = "친구 프로필 ID", example = "1")
 	private long friendProfileId;
 	@Schema(description = "친구 프로필 이름", example = "홍길동99")
-	private String displayName;
+	private String friendName;
 	@Schema(description = "친구 프로필 상태메시지", example = "hi there")
 	private String bio;
 	@Schema(description = "친구 프로필 이미지 주소", example = "http://profile/image/url")
@@ -26,7 +26,7 @@ public class FriendSynchronizeResponse {
 	public static FriendSynchronizeResponse of(Profile profile, Friend friend) {
 		return new FriendSynchronizeResponse(
 			profile.getId(),
-			friend.getDisplayName(),
+			friend.getFriendName(),
 			profile.getBio(),
 			profile.getLatestProfileImageUrl(),
 			friend.getStatus()

--- a/src/main/java/com/avalon/avalonchat/core/profile/domain/ProfileRepository.java
+++ b/src/main/java/com/avalon/avalonchat/core/profile/domain/ProfileRepository.java
@@ -15,6 +15,8 @@ public interface ProfileRepository extends JpaRepository<Profile, Long> {
 
 	Optional<Profile> findByPhoneNumber(String phoneNumber);
 
+	Optional<Profile> findByPhoneNumberAndNickname(String phoneNumber, String nickname);
+
 	@Query("SELECT p.id "
 		+ "FROM Profile p "
 		+ "WHERE p.user.id = :userId")

--- a/src/main/java/com/avalon/avalonchat/core/profile/domain/ProfileRepository.java
+++ b/src/main/java/com/avalon/avalonchat/core/profile/domain/ProfileRepository.java
@@ -13,7 +13,7 @@ import com.avalon.avalonchat.core.user.domain.Email;
 public interface ProfileRepository extends JpaRepository<Profile, Long> {
 	List<Profile> findAllByPhoneNumberIn(List<String> phoneNumbers);
 
-	Optional<Profile> findByPhoneNumber(String phoneNumbers);
+	Optional<Profile> findByPhoneNumber(String phoneNumber);
 
 	@Query("SELECT p.id "
 		+ "FROM Profile p "

--- a/src/test/java/com/avalon/avalonchat/core/friend/application/FriendServiceImplTest.java
+++ b/src/test/java/com/avalon/avalonchat/core/friend/application/FriendServiceImplTest.java
@@ -70,14 +70,14 @@ class FriendServiceImplTest {
 		profileRepository.saveAll(List.of(myProfile, friendProfile));
 
 		FriendPhoneNumberAddRequest request
-			= friendPhoneNumberAddRequest("010-1234-5678", "홍길동99");
+			= friendPhoneNumberAddRequest("010-1234-5678", "홍길동");
 
 		// when
 		FriendPhoneNumberAddResponse response = sut.addFriendByPhoneNumber(myProfile.getId(), request);
 
 		// then
 		assertThat(response.getFriendProfileId()).isEqualTo(friendProfile.getId());
-		assertThat(response.getDisplayName()).isEqualTo(request.getDisplayName());
+		assertThat(response.getFriendName()).isEqualTo(request.getFriendProfileNickname());
 		assertThat(response.getBio()).isEqualTo(friendProfile.getBio());
 		assertThat(response.getProfileImage()).isEqualTo(friendProfile.getLatestProfileImageUrl());
 		assertThat(response.getStatus()).isEqualTo(Status.NORMAL);
@@ -156,7 +156,7 @@ class FriendServiceImplTest {
 		// then
 		assertThat(responses).hasSize(1);
 		assertThat(responses.get(0).getFriendProfileId()).isEqualTo(newFriendProfile.getId());
-		assertThat(responses.get(0).getDisplayName()).isEqualTo(friendsInfo.get("010-1234-5678"));
+		assertThat(responses.get(0).getFriendName()).isEqualTo(friendsInfo.get("010-1234-5678"));
 		assertThat(responses.get(0).getBio()).isEqualTo(newFriendProfile.getBio());
 		assertThat(responses.get(0).getProfileImage()).isEqualTo(newFriendProfile.getLatestProfileImageUrl());
 		assertThat(responses.get(0).getStatus()).isEqualTo(Status.NORMAL);
@@ -177,7 +177,7 @@ class FriendServiceImplTest {
 		Profile savedFriendProfile = profileRepository.save(friendProfile);
 
 		// given - ready for friend
-		Friend friend = new Friend(savedMyProfile, savedFriendProfile);
+		Friend friend = new Friend(savedMyProfile, savedFriendProfile, "friendNickname");
 		friendRepository.save(friend);
 
 		// given - ready for the request

--- a/src/test/java/com/avalon/avalonchat/core/friend/domain/FriendRepositoryTest.java
+++ b/src/test/java/com/avalon/avalonchat/core/friend/domain/FriendRepositoryTest.java
@@ -40,7 +40,7 @@ class FriendRepositoryTest {
 		Profile myProfile = new Profile(myUser, "bio1", LocalDate.now(), "nickname1", phoneNumber);
 		Profile friendProfile = new Profile(friendUser, "bio2", LocalDate.now(), "nickname2", phoneNumber);
 
-		Friend friend = new Friend(myProfile, friendProfile);
+		Friend friend = new Friend(myProfile, friendProfile, "nickname2");
 
 		// when
 		Friend savedFriend = friendRepository.save(friend);
@@ -61,8 +61,8 @@ class FriendRepositoryTest {
 		User friendUser2 = new User(Email.of("email3@gmail.com"), Password.of("password3"));
 		Profile friendProfile2 = new Profile(friendUser2, "bio4", LocalDate.now(), "nickname4", "01055110628");
 
-		Friend friend1 = new Friend(myProfile, friendProfile1);
-		Friend friend2 = new Friend(myProfile, friendProfile2);
+		Friend friend1 = new Friend(myProfile, friendProfile1, "nickname2");
+		Friend friend2 = new Friend(myProfile, friendProfile2, "nickname4");
 
 		userRepository.save(myUser);
 		userRepository.save(friendUser1);
@@ -97,7 +97,7 @@ class FriendRepositoryTest {
 		for (int i = 0; i < 10; i++) {
 			User friendUser = new User(Email.of("email@gmail" + i + ".com"), Password.of("password" + i));
 			Profile friendProfile = new Profile(friendUser, "bio", LocalDate.now(), "nickname", "01055110626" + i);
-			Friend friend = new Friend(myProfile, friendProfile);
+			Friend friend = new Friend(myProfile, friendProfile, "nickname");
 
 			userRepository.save(friendUser);
 			profileRepository.save(friendProfile);
@@ -128,7 +128,7 @@ class FriendRepositoryTest {
 		Profile savedFriendProfile = profileRepository.save(friendProfile);
 
 		// given - ready for friend
-		Friend friend = new Friend(savedMyProfile, savedFriendProfile);
+		Friend friend = new Friend(savedMyProfile, savedFriendProfile, "friendNickname");
 		friendRepository.save(friend);
 
 		// when

--- a/src/test/java/com/avalon/avalonchat/core/friend/domain/FriendRepositoryTest.java
+++ b/src/test/java/com/avalon/avalonchat/core/friend/domain/FriendRepositoryTest.java
@@ -11,7 +11,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.avalon.avalonchat.core.friend.dto.FriendAddResponse;
 import com.avalon.avalonchat.core.profile.domain.Profile;
 import com.avalon.avalonchat.core.profile.domain.ProfileRepository;
 import com.avalon.avalonchat.core.user.domain.Email;
@@ -139,42 +138,5 @@ class FriendRepositoryTest {
 		// then
 		assertThat(foundFriend.getMyProfile().getId()).isEqualTo(savedMyProfile.getId());
 		assertThat(foundFriend.getFriendProfile().getId()).isEqualTo(savedFriendProfile.getId());
-	}
-
-	@Test
-	void friendIds로_추가된_친구_프로필찾기성공() {
-		// given - ready for users & profiles
-		User myUser = new User(Email.of("myUser@gmail.com"), Password.of("myPassword"));
-		Profile myProfile = new Profile(myUser, "myBio", LocalDate.now(), "myProfile", "01012345678");
-
-		User friendUser1 = new User(Email.of("friendUser1@gmail.com"), Password.of("friendPassword"));
-		Profile friendProfile1 = new Profile(friendUser1, "friendBio1", LocalDate.now(), "friendNickname1",
-			"01012123434");
-		User friendUser2 = new User(Email.of("friendUser2@gmail.com"), Password.of("friendPassword"));
-		Profile friendProfile2 = new Profile(friendUser2, "friendBio2", LocalDate.now(), "friendNickname2",
-			"01011112222");
-
-		userRepository.save(myUser);
-		userRepository.save(friendUser1);
-		userRepository.save(friendUser2);
-		Profile savedMyProfile = profileRepository.save(myProfile);
-		Profile savedFriendProfile1 = profileRepository.save(friendProfile1);
-		Profile savedFriendProfile2 = profileRepository.save(friendProfile2);
-
-		// given - ready for friend
-		Friend friend1 = new Friend(savedMyProfile, savedFriendProfile1);
-		Friend friend2 = new Friend(savedMyProfile, savedFriendProfile2);
-
-		friendRepository.save(friend1);
-		friendRepository.save(friend2);
-
-		// when
-		List<Long> friendIds = new ArrayList<>();
-		friendIds.add(friend1.getId());
-		friendIds.add(friend2.getId());
-		List<FriendAddResponse> responses = friendRepository.findAllByFriendIds(friendIds);
-
-		// then
-		assertThat(responses.size()).isEqualTo(2);
 	}
 }

--- a/src/test/java/com/avalon/avalonchat/core/friend/domain/FriendTest.java
+++ b/src/test/java/com/avalon/avalonchat/core/friend/domain/FriendTest.java
@@ -24,7 +24,7 @@ class FriendTest {
 		Profile friendProfile = new Profile(friendUser, "bio2", LocalDate.now(), "nickname2", phoneNumber);
 
 		//when
-		Friend friend = new Friend(myProfile, friendProfile);
+		Friend friend = new Friend(myProfile, friendProfile, "nickname2");
 
 		//then
 		assertThat(friend.getMyProfile()).isEqualTo(myProfile);

--- a/src/test/java/com/avalon/avalonchat/core/profile/application/ProfileServiceImplTest.java
+++ b/src/test/java/com/avalon/avalonchat/core/profile/application/ProfileServiceImplTest.java
@@ -169,7 +169,7 @@ class ProfileServiceImplTest {
 		profileRepository.save(friendProfile);
 
 		// given - ready for friends
-		Friend friend = new Friend(myProfile, friendProfile);
+		Friend friend = new Friend(myProfile, friendProfile, "A_friend");
 		friendRepository.save(friend);
 
 		//when
@@ -229,8 +229,8 @@ class ProfileServiceImplTest {
 		profileRepository.save(friendProfile2);
 
 		// given - ready for friends
-		Friend friend1 = new Friend(myProfile, friendProfile1);
-		Friend friend2 = new Friend(myProfile, friendProfile2);
+		Friend friend1 = new Friend(myProfile, friendProfile1, "A_friend");
+		Friend friend2 = new Friend(myProfile, friendProfile2, "B_friend");
 		friendRepository.save(friend1);
 		friendRepository.save(friend2);
 

--- a/src/test/java/com/avalon/avalonchat/core/profile/domain/ProfileRepositoryTest.java
+++ b/src/test/java/com/avalon/avalonchat/core/profile/domain/ProfileRepositoryTest.java
@@ -104,8 +104,8 @@ class ProfileRepositoryTest {
 		friendProfile2.addProfileImage("url4");
 		sut.saveAll(List.of(myProfile, friendProfile1, friendProfile2));
 
-		Friend friend1 = createFriend(myProfile, friendProfile1);
-		Friend friend2 = createFriend(myProfile, friendProfile2);
+		Friend friend1 = createFriend(myProfile, friendProfile1, "A_friend");
+		Friend friend2 = createFriend(myProfile, friendProfile2, "B_friend");
 		friendRepository.saveAll(List.of(friend1, friend2));
 
 		// when
@@ -166,8 +166,8 @@ class ProfileRepositoryTest {
 		);
 		sut.saveAll(List.of(myProfile, friendProfile1, friendProfile2));
 
-		Friend friend1 = createFriend(myProfile, friendProfile1);
-		Friend friend2 = createFriend(myProfile, friendProfile2);
+		Friend friend1 = createFriend(myProfile, friendProfile1, "A_friend");
+		Friend friend2 = createFriend(myProfile, friendProfile2, "B_friend");
 		friendRepository.saveAll(List.of(friend1, friend2));
 
 		// when

--- a/src/test/java/com/avalon/avalonchat/testsupport/DtoFixture.java
+++ b/src/test/java/com/avalon/avalonchat/testsupport/DtoFixture.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 import com.avalon.avalonchat.core.friend.dto.FriendAddRequest;
+import com.avalon.avalonchat.core.friend.dto.FriendPhoneNumberAddRequest;
 import com.avalon.avalonchat.core.login.dto.LoginRequest;
 import com.avalon.avalonchat.core.profile.dto.BackgroundImageDeleteRequest;
 import com.avalon.avalonchat.core.profile.dto.ProfileImageDeleteRequest;
@@ -112,4 +113,10 @@ public final class DtoFixture {
 		return new BackgroundImageDeleteRequest(deletedBackgroundImageUrls);
 	}
 	/* Profile Package DTO End */
+
+	/* Friend Package DTO Start */
+	public static FriendPhoneNumberAddRequest friendPhoneNumberAddRequest(String phoneNumber, String displayName) {
+		return new FriendPhoneNumberAddRequest(phoneNumber, displayName);
+	}
+	/* Friend Package DTO End */
 }

--- a/src/test/java/com/avalon/avalonchat/testsupport/DtoFixture.java
+++ b/src/test/java/com/avalon/avalonchat/testsupport/DtoFixture.java
@@ -2,9 +2,10 @@ package com.avalon.avalonchat.testsupport;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 
-import com.avalon.avalonchat.core.friend.dto.FriendAddRequest;
 import com.avalon.avalonchat.core.friend.dto.FriendPhoneNumberAddRequest;
+import com.avalon.avalonchat.core.friend.dto.FriendSynchronizeRequest;
 import com.avalon.avalonchat.core.login.dto.LoginRequest;
 import com.avalon.avalonchat.core.profile.dto.BackgroundImageDeleteRequest;
 import com.avalon.avalonchat.core.profile.dto.ProfileImageDeleteRequest;
@@ -83,10 +84,6 @@ public final class DtoFixture {
 	}
 	/* Login Package DTO End */
 
-	public static FriendAddRequest friendAddRequest(List<String> phoneNumbers) {
-		return new FriendAddRequest(phoneNumbers);
-	}
-
 	/* Profile Package DTO Start */
 	public static ProfileUpdateRequest profileUpdateRequest(
 		LocalDate birthDate,
@@ -117,6 +114,10 @@ public final class DtoFixture {
 	/* Friend Package DTO Start */
 	public static FriendPhoneNumberAddRequest friendPhoneNumberAddRequest(String phoneNumber, String displayName) {
 		return new FriendPhoneNumberAddRequest(phoneNumber, displayName);
+	}
+
+	public static FriendSynchronizeRequest friendSynchronizeRequest(Map<String, String> friendsInfo) {
+		return new FriendSynchronizeRequest(friendsInfo);
 	}
 	/* Friend Package DTO End */
 }

--- a/src/test/java/com/avalon/avalonchat/testsupport/Fixture.java
+++ b/src/test/java/com/avalon/avalonchat/testsupport/Fixture.java
@@ -47,6 +47,10 @@ public final class Fixture {
 		);
 	}
 
+	public static Friend createFriend(Profile myProfile, Profile friendProfile, String displayName) {
+		return new Friend(myProfile, friendProfile, displayName);
+	}
+
 	public static Friend createFriend(Profile myProfile, Profile friendProfile) {
 		return new Friend(myProfile, friendProfile);
 	}

--- a/src/test/java/com/avalon/avalonchat/testsupport/Fixture.java
+++ b/src/test/java/com/avalon/avalonchat/testsupport/Fixture.java
@@ -47,11 +47,11 @@ public final class Fixture {
 		);
 	}
 
-	public static Friend createFriend(Profile myProfile, Profile friendProfile, String displayName) {
-		return new Friend(myProfile, friendProfile, displayName);
+	public static Friend createFriend(Profile myProfile, Profile friendProfile, String friendName) {
+		return new Friend(myProfile, friendProfile, friendName);
 	}
 
-	public static Friend createFriend(Profile myProfile, Profile friendProfile) {
-		return new Friend(myProfile, friendProfile);
-	}
+	// public static Friend createFriend(Profile myProfile, Profile friendProfile, String friendName) {
+	// 	return new Friend(myProfile, friendProfile);
+	// }
 }


### PR DESCRIPTION
## Summary

*연락처로 친구 추가 API 구현.*
*친구 동기화 API 수정*
*`Friend` 테이블 수정*

## (Optional): Description

*연락처에 저장된 이름으로 친구이름 표출하기 위해 `Friend` 테이블에 `displayName` 컬럼 추가.*
*연락처를 통해 단건으로 친구추가 하는 API 추가.*
*친구 동기화의 전반적인 이름을 `add` -> `synchronize`로 변경.*
*친구 동기화 요청 dto의 필드를 Map 형태(`{"핸드폰 번호":"이름", ..}`)로 수정.*

## How Has This Been Tested?

*서비스의 테스트 코드*

## Ps
- 친구 동기화 API와 친구 추가 API를 구분하기 위해 사용되는 변수명의 add를 synchronize로 변경하였습니다.
- 친구 동기화시, 한꺼번에 여러개의 연락처와 이름을 받아와야 하기 때문에 이 둘을 정확히 매핑할 수 있도록 Map 형태로 받도록 짜보았습니다.
